### PR TITLE
[Proposal] Sign post but skip files

### DIFF
--- a/src/Oauth1.php
+++ b/src/Oauth1.php
@@ -65,6 +65,7 @@ class Oauth1 implements SubscriberInterface
             'consumer_key'     => 'anonymous',
             'consumer_secret'  => 'anonymous',
             'signature_method' => self::SIGNATURE_METHOD_HMAC,
+            'unsigned_params'  => array(),
         ], ['signature_method', 'version', 'consumer_key', 'consumer_secret']);
     }
 
@@ -124,11 +125,8 @@ class Oauth1 implements SubscriberInterface
 
         // Add POST fields if the request uses POST fields and no files
         $body = $request->getBody();
-        if ($body instanceof PostBodyInterface) {
+        if ($body instanceof PostBodyInterface && !$body->getFiles()) {
             $params += Query::fromString($body->getFields(true))->toArray();
-            foreach($body->getFiles() as $file){
-                unset($params[$file->getName()]);
-            }
         }
 
         // Parse & add query string parameters as base string parameters
@@ -207,7 +205,7 @@ class Oauth1 implements SubscriberInterface
         uksort($data, 'strcmp');
 
         foreach ($data as $key => $value) {
-            if ($value === null) {
+            if ($value === null || in_array($key, $this->config['unsigned_params'])) {
                 unset($data[$key]);
             }
         }

--- a/src/Oauth1.php
+++ b/src/Oauth1.php
@@ -65,6 +65,7 @@ class Oauth1 implements SubscriberInterface
             'consumer_key'     => 'anonymous',
             'consumer_secret'  => 'anonymous',
             'signature_method' => self::SIGNATURE_METHOD_HMAC,
+            'sign_multipart'   => false,
             'unsigned_params'  => array(),
         ], ['signature_method', 'version', 'consumer_key', 'consumer_secret']);
     }
@@ -125,7 +126,7 @@ class Oauth1 implements SubscriberInterface
 
         // Add POST fields if the request uses POST fields and no files
         $body = $request->getBody();
-        if ($body instanceof PostBodyInterface && !$body->getFiles()) {
+        if ($body instanceof PostBodyInterface && (!$body->getFiles() || $this->config['sign_multipart'])) {
             $params += Query::fromString($body->getFields(true))->toArray();
         }
 

--- a/src/Oauth1.php
+++ b/src/Oauth1.php
@@ -124,8 +124,11 @@ class Oauth1 implements SubscriberInterface
 
         // Add POST fields if the request uses POST fields and no files
         $body = $request->getBody();
-        if ($body instanceof PostBodyInterface && !$body->getFiles()) {
+        if ($body instanceof PostBodyInterface) {
             $params += Query::fromString($body->getFields(true))->toArray();
+            foreach($body->getFiles() as $file){
+                unset($params[$file->getName()]);
+            }
         }
 
         // Parse & add query string parameters as base string parameters


### PR DESCRIPTION
This commit signs post request which have files, but doesn't use them for signing.
I don't know what is in the spec about this, or what is common to do, but the Flickr API for uploading files (https://www.flickr.com/services/api/upload.api.html) uses OAuth 1 and says: 

> Note that the 'photo' parameter should not be included in the signature. All other POST parameters should be included when generating the signature.

I'm not sure if this is the correct way to do it, or that there is another way to accomplish this?
