### PR TITLE
Adding getters and setters for ->config.

### DIFF
--- a/src/Oauth1.php
+++ b/src/Oauth1.php
@@ -57,7 +57,17 @@ class Oauth1 implements SubscriberInterface
      *
      * @param array $config Configuration array.
      */
-    public function __construct($config)
+    public function __construct(array $config)
+    {
+        $this->setConfig($config);
+    }
+
+    public function getConfig()
+    {
+        return $this->config;
+    }
+
+    public function setConfig(array $config)
     {
         $this->config = Collection::fromConfig($config, [
             'version'          => '1.0',
@@ -66,6 +76,7 @@ class Oauth1 implements SubscriberInterface
             'consumer_secret'  => 'anonymous',
             'signature_method' => self::SIGNATURE_METHOD_HMAC,
         ], ['signature_method', 'version', 'consumer_key', 'consumer_secret']);
+        return $this;
     }
 
     public function getEvents()

--- a/tests/Oauth1Test.php
+++ b/tests/Oauth1Test.php
@@ -40,11 +40,7 @@ class Oauth1Test extends \PHPUnit_Framework_TestCase
     {
         $p = new Oauth1($this->config);
 
-        // Access the config object
-        $class = new \ReflectionClass($p);
-        $property = $class->getProperty('config');
-        $property->setAccessible(true);
-        $config = $property->getValue($p);
+        $config = $p->getConfig();
 
         $this->assertEquals('foo', $config['consumer_key']);
         $this->assertEquals('bar', $config['consumer_secret']);


### PR DESCRIPTION
This is so that I can authenticate lots of different consumers using the same client without having to recreate the subscriber object for each request.
