### PR TITLE
Fix Twitter example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ REST API:
     use GuzzleHttp\Client;
     use GuzzleHttp\Subscriber\Oauth\Oauth1;
 
-    $client = new Client(['base_url' => 'http://api.twitter.com/1.1']);
+    $client = new Client(['base_url' => 'https://api.twitter.com/1.1/']);
 
     $oauth = new Oauth1([
         'consumer_key'    => 'my_key',
@@ -54,7 +54,7 @@ the client using the client's ``defaults`` constructor option.
     use GuzzleHttp\Client;
 
     $client = new Client([
-        'base_url' => 'http://api.twitter.com/1.1',
+        'base_url' => 'https://api.twitter.com/1.1/',
         'defaults' => ['auth' => 'oauth']
     ]);
 


### PR DESCRIPTION
It's just an example, but a bit frustring if the example doesn't work ;)
1. Twitter API is https only
2. When the base_url doesn't end with an `/`, it isn't used. (Not sure if that is intentional..)
