### PR TITLE
Fixed signing of passphrase protected RSA keys; tidied config naming.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,3 +66,18 @@ the client using the client's ``defaults`` constructor option.
 .. note::
 
     You can omit the token and token_secret options to use two-legged OAuth.
+
+Using the RSA-SH1 signature method
+==================================
+
+.. code-block:: php
+
+    use GuzzleHttp\Subscriber\Oauth\Oauth1;
+
+    $oauth = new Oauth1([
+        'consumer_key'    => 'my_key',
+        'consumer_secret' => 'my_secret',
+        'private_key_file' => 'my_path_to_private_key_file',
+        'private_key_passphrase' => 'my_passphrase',
+        'signature_method' => Oauth1::SIGNATURE_METHOD_RSA,
+    ]);

--- a/src/Oauth1.php
+++ b/src/Oauth1.php
@@ -48,6 +48,8 @@ class Oauth1 implements SubscriberInterface
      * - callback: OAuth callback
      * - consumer_key: Consumer key string. Defaults to "anonymous".
      * - consumer_secret: Consumer secret. Defaults to "anonymous".
+     * - private_key_file: The location of your private key file (RSA-SHA1 signature method only)
+     * - private_key_passphrase: The passphrase for your private key file (RSA-SHA1 signature method only)
      * - token: Client token
      * - token_secret: Client secret token
      * - verifier: OAuth verifier.
@@ -231,8 +233,8 @@ class Oauth1 implements SubscriberInterface
         }
 
         $privateKey = openssl_pkey_get_private(
-            file_get_contents($this->config['consumer_secret']),
-            $this->config['consumer_secret']
+            file_get_contents($this->config['private_key_file']),
+            $this->config['private_key_passphrase']
         );
 
         $signature = false;


### PR DESCRIPTION
Proposed fix for issue #15.

If you've been using ```SIGNATURE_METHOD_RSA```, this change is not backwards compatible.

I have added two new ```SIGNATURE_METHOD_RSA```-specific configuration options:

* ```private_key_file```
* ```private_key_passphrase```

These are passed to ```openssl_pkey_get_private()```.

The old code was using the ```consumer_key``` option for both file and passphrase, meaning it was unlikely to work unless:

* Your key had no passphrase, or
* You used the file location name as a passphrase (please don't do this)

I have added a usage example to the README.