### PR TITLE
Current release is v0.2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "0.1-dev"
+            "dev-master": "0.2.x-dev"
         }
     }
 }


### PR DESCRIPTION
Hi,

I need the RSA fix in order to get stuff to work, however adding `@dev` to `0.2.*` did not fetch the latest master for me, I had to change back to `0.1.*@dev`.

Could you do a patch release after this change, to make RSA work?