### PR TITLE
Add oauth_body_hash parameter to authorization header

### DIFF
--- a/src/Oauth1.php
+++ b/src/Oauth1.php
@@ -317,7 +317,7 @@ class Oauth1 implements SubscriberInterface
             'callback'  => 'oauth_callback',
             'token'     => 'oauth_token',
             'verifier'  => 'oauth_verifier',
-            'version'   => 'oauth_version'
+            'version'   => 'oauth_version',
             'bodyhash'  => 'oauth_body_hash'
         ];
 


### PR DESCRIPTION
Hi,

It'd be great to add the oauth_body_hash to the OAuth authorization header.  I've added it as an optional parameter to the config.  The reason for this instead of having the OAuth1 class handling the hashing is because the hashing is dependent on which signature method chosen to create the signature.

As an example LTI service requests require this parameter when sending a service request back to the LMS such as the outcomes service.

Example usage (when using the HMAC-SHA1 signature method and 2-legged OAuth 1):

``` php

$bodyHash = base64_encode(sha1($requestBody, TRUE));

$oAuth = new GuzzleHttp\Subscriber\Oauth\Oauth1([
    'consumer_key' => $consumerKey,
    'consumer_secret' => $consumerSecret,
    'signature_method' => GuzzleHttp\Subscriber\Oauth\Oauth1::SIGNATURE_METHOD_HMAC,
    'bodyhash' => $bodyHash
]);

$client = new GuzzleHttp\Client(['base_url' => $url, 'defaults' => [
    'auth' => 'oauth',
    'subscribers' => [$oAuth]
]]);

$request = $client->createRequest('POST', $url, array(
    'body' => $requestBody
));

$response = $client->send($request);

```
