### PR TITLE
Update composer require version in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ composer.json:
 
     {
         "require": {
-            "guzzlehttp/oauth-subscriber": "0.1.*"
+            "guzzlehttp/oauth-subscriber": "0.2.*"
         }
     }
 


### PR DESCRIPTION
Seems there is a 0.2.0 release and that the readme should reflect this.