### PR TITLE
Added support for Guzzle 6.0+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,13 @@ php:
   - 5.5
   - 5.6
   - 7.0
-  - hhvm
-
-matrix:
-  allow-failures:
-    - php: hhvm
-    - php: 7.0
+  - hhvm-nightly
 
 before_script:
-  - composer self-update
-  - composer install --no-interaction --prefer-source --dev
+  - curl --version
+
+install:
+  - travis_retry composer self-update
+  - travis_retry composer install --no-interaction
 
 script: vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,13 @@ php:
   - 5.5
   - 5.6
   - 7.0
-  - hhvm-nightly
+  - hhvm
+
+matrix:
+  allow_failures:
+    - php: hhvm
+    - php: 7.0
+  fast_finish: true
 
 before_script:
   - curl --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,8 @@ matrix:
     - php: 7.0
   fast_finish: true
 
-before_script:
-  - curl --version
-
 install:
   - travis_retry composer self-update
-  - travis_retry composer install --no-interaction
+  - travis_retry composer install --no-interaction --prefer-source
 
 script: vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,15 @@
 language: php
 
 php:
-  - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
+
+matrix:
+  allow-failures:
+    - php: hhvm
+    - php: 7.0
 
 before_script:
   - composer self-update

--- a/README.rst
+++ b/README.rst
@@ -5,6 +5,8 @@ Guzzle OAuth Subscriber
 Signs HTTP requests using OAuth 1.0. Requests are signed using a consumer key,
 consumer secret, OAuth token, and OAuth secret.
 
+This version only works with Guzzle 6.0 and up!
+
 Installing
 ==========
 
@@ -15,7 +17,7 @@ composer.json:
 
     {
         "require": {
-            "guzzlehttp/oauth-subscriber": "0.1.*"
+            "guzzlehttp/oauth-subscriber": "0.2.*"
         }
     }
 
@@ -30,18 +32,23 @@ REST API:
 .. code-block:: php
 
     use GuzzleHttp\Client;
+    use GuzzleHttp\HandlerStack;
     use GuzzleHttp\Subscriber\Oauth\Oauth1;
 
-    $client = new Client(['base_url' => 'https://api.twitter.com/1.1/']);
+    $stack = HandlerStack::create();
 
-    $oauth = new Oauth1([
+    $middleware = new Oauth1([
         'consumer_key'    => 'my_key',
         'consumer_secret' => 'my_secret',
         'token'           => 'my_token',
         'token_secret'    => 'my_token_secret'
     ]);
+    $stack->push($middleware);
 
-    $client->getEmitter()->attach($oauth);
+    $client = new Client([
+        'base_url' => 'https://api.twitter.com/1.1/',
+        'handler' => $stack
+    ]);
 
     // Set the "auth" request option to "oauth" to sign using oauth
     $res = $client->get('statuses/home_timeline.json', ['auth' => 'oauth']);
@@ -52,13 +59,24 @@ the client using the client's ``defaults`` constructor option.
 .. code-block:: php
 
     use GuzzleHttp\Client;
+    use GuzzleHttp\HandlerStack;
+    use GuzzleHttp\Subscriber\Oauth\Oauth1;
+
+    $stack = HandlerStack::create();
+
+    $middleware = new Oauth1([
+        'consumer_key'    => 'my_key',
+        'consumer_secret' => 'my_secret',
+        'token'           => 'my_token',
+        'token_secret'    => 'my_token_secret'
+    ]);
+    $stack->push($middleware);
 
     $client = new Client([
         'base_url' => 'https://api.twitter.com/1.1/',
+        'handler' => $stack,
         'defaults' => ['auth' => 'oauth']
     ]);
-
-    $client->getEmitter()->attach($oauth);
 
     // Now you don't need to add the auth parameter
     $res = $client->get('statuses/home_timeline.json');

--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ REST API:
     $stack->push($middleware);
 
     $client = new Client([
-        'base_url' => 'https://api.twitter.com/1.1/',
+        'base_uri' => 'https://api.twitter.com/1.1/',
         'handler' => $stack
     ]);
 
@@ -54,7 +54,7 @@ REST API:
     $res = $client->get('statuses/home_timeline.json', ['auth' => 'oauth']);
 
 You can set the ``auth`` request option to ``oauth`` for all requests sent by
-the client using the client's ``defaults`` constructor option.
+the client by extending the array you feed to ``new Client`` with auth => oauth.
 
 .. code-block:: php
 
@@ -73,9 +73,9 @@ the client using the client's ``defaults`` constructor option.
     $stack->push($middleware);
 
     $client = new Client([
-        'base_url' => 'https://api.twitter.com/1.1/',
+        'base_uri' => 'https://api.twitter.com/1.1/',
         'handler' => $stack,
-        'defaults' => ['auth' => 'oauth']
+        'auth' => 'oauth'
     ]);
 
     // Now you don't need to add the auth parameter
@@ -92,10 +92,19 @@ Using the RSA-SH1 signature method
 
     use GuzzleHttp\Subscriber\Oauth\Oauth1;
 
-    $oauth = new Oauth1([
+    $stack = HandlerStack::create();
+
+    $middleware = new Oauth1([
         'consumer_key'    => 'my_key',
         'consumer_secret' => 'my_secret',
         'private_key_file' => 'my_path_to_private_key_file',
         'private_key_passphrase' => 'my_passphrase',
         'signature_method' => Oauth1::SIGNATURE_METHOD_RSA,
     ]);
+    $stack->push($middleware);
+
+    $client = new Client([
+        'handler' => $stack
+    ]);
+
+    $response = $client->get('http://httpbin.org', ['auth' => 'oauth']);

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
-        "guzzlehttp/guzzle": "~4.0|~5.0"
+        "php": ">=5.5.0",
+        "guzzlehttp/guzzle": "~6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0"

--- a/src/Oauth1.php
+++ b/src/Oauth1.php
@@ -108,8 +108,8 @@ class Oauth1
                 break;
             case self::REQUEST_METHOD_QUERY:
                 $queryparams = \GuzzleHttp\Psr7\parse_query($request->getUri()->getQuery());
-                $preparedParams = \GuzzleHttp\Psr7\build_query($oauthparams + $queryparams));
-                $request = $request->withUri($request->getUri()->withQuery($preparedParams);
+                $preparedParams = \GuzzleHttp\Psr7\build_query($oauthparams + $queryparams);
+                $request = $request->withUri($request->getUri()->withQuery($preparedParams));
                 break;
             default:
                 throw new \InvalidArgumentException(sprintf(

--- a/src/Oauth1.php
+++ b/src/Oauth1.php
@@ -308,7 +308,7 @@ class Oauth1
      *
      * @return array
      */
-    private function getOauthParams($nonce, $config)
+    private function getOauthParams($nonce, array $config)
     {
         $params = [
             'oauth_consumer_key'     => $config['consumer_key'],

--- a/src/Oauth1.php
+++ b/src/Oauth1.php
@@ -67,8 +67,7 @@ class Oauth1
             'signature_method' => self::SIGNATURE_METHOD_HMAC,
         ];
 
-        foreach ($config as $key => $value)
-        {
+        foreach ($config as $key => $value) {
             $this->config[$key] = $value;
         }
     }
@@ -84,14 +83,15 @@ class Oauth1
     {
         return function ($request, array $options) use ($handler) {
 
-            if (isset($options['auth']) && $options['auth'] == 'oauth')
+            if (isset($options['auth']) && $options['auth'] == 'oauth') {
                 $request = $this->onBefore($request);
+            }
 
             return $handler($request, $options);
         };
     }
 
-    public function onBefore(RequestInterface $request)
+    private function onBefore(RequestInterface $request)
     {
         $params = $this->getOauthParams(
             $this->generateNonce($request),

--- a/src/Oauth1.php
+++ b/src/Oauth1.php
@@ -93,21 +93,23 @@ class Oauth1
 
     private function onBefore(RequestInterface $request)
     {
-        $params = $this->getOauthParams(
+        $oauthparams = $this->getOauthParams(
             $this->generateNonce($request),
             $this->config
         );
 
-        $params['oauth_signature'] = $this->getSignature($request, $params);
-        uksort($params, 'strcmp');
+        $oauthparams['oauth_signature'] = $this->getSignature($request, $oauthparams);
+        uksort($oauthparams, 'strcmp');
 
         switch ($this->config['request_method']) {
             case self::REQUEST_METHOD_HEADER:
-                list($header, $value) = $this->buildAuthorizationHeader($params);
+                list($header, $value) = $this->buildAuthorizationHeader($oauthparams);
                 $request = $request->withHeader($header, $value);
                 break;
             case self::REQUEST_METHOD_QUERY:
-                $request = $request->withUri($request->getUri()->withQuery(\GuzzleHttp\Psr7\build_query($params)));
+                $queryparams = \GuzzleHttp\Psr7\parse_query($request->getUri()->getQuery());
+                $preparedParams = \GuzzleHttp\Psr7\build_query($oauthparams + $queryparams));
+                $request = $request->withUri($request->getUri()->withQuery($preparedParams);
                 break;
             default:
                 throw new \InvalidArgumentException(sprintf(

--- a/src/Oauth1.php
+++ b/src/Oauth1.php
@@ -136,8 +136,8 @@ class Oauth1
         unset($params['oauth_signature']);
 
         // Add POST fields if the request uses POST fields and no files
-        $body = \GuzzleHttp\Psr7\parse_query($request->getBody()->getContents());
-        if (is_array($body) && count($body) > 1) {
+        if ($request->getHeaderLine('Content-Type') == 'application/x-www-form-urlencoded') {
+            $body = \GuzzleHttp\Psr7\parse_query($request->getBody()->getContents());
             $params += $body;
         }
 

--- a/tests/Oauth1Test.php
+++ b/tests/Oauth1Test.php
@@ -2,14 +2,12 @@
 
 namespace GuzzleHttp\Tests\Oauth1;
 
-use GuzzleHttp\Transaction;
 use GuzzleHttp\Client;
-use GuzzleHttp\Event\BeforeEvent;
 use GuzzleHttp\Exception\ClientException;
-use GuzzleHttp\Message\Request;
-use GuzzleHttp\Post\PostBody;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Subscriber\Oauth\Oauth1;
-use GuzzleHttp\Stream\Utils;
 
 class Oauth1Test extends \PHPUnit_Framework_TestCase
 {
@@ -23,18 +21,18 @@ class Oauth1Test extends \PHPUnit_Framework_TestCase
         'token_secret'    => 'dracula'
     ];
 
-    protected function getRequest()
+    public function testFirst()
     {
-        $body = new PostBody();
-        $body->setField('e', 'f');
+        $stack = HandlerStack::create();
 
-        return new Request('POST', 'http://www.test.com/path?a=b&c=d', [], $body);
-    }
+        $middleware = new Oauth1($this->config);
+        $stack->push($middleware);
 
-    public function testSubscribesToEvents()
-    {
-        $events = (new Oauth1([]))->getEvents();
-        $this->assertArrayHasKey('before', $events);
+        $client = new Client([
+            'handler' => $stack
+        ]);
+
+        $request = $client->put('http://requestb.in/1955mwl1', ['auth' => 'oauth', 'body' => '{"testing":"test123"}']);
     }
 
     public function testAcceptsConfigurationData()
@@ -58,19 +56,32 @@ class Oauth1Test extends \PHPUnit_Framework_TestCase
 
     public function testCreatesStringToSignFromPostRequest()
     {
-        $s = new Oauth1($this->config);
-        $client = new Client();
-        $request = $client->createRequest('POST', 'http://httpbin.org', [
+        $stack = HandlerStack::create();
+
+        $middleware = new Oauth1($this->config);
+        $stack->push($middleware);
+
+        $container = [];
+        $history = Middleware::history($container);
+        $stack->push($history);
+
+        $client = new Client([
+            'handler' => $stack
+        ]);
+
+        $client->post('http://httpbin.org/post', [
             'auth' => 'oauth',
-            'body' => [
+            'form_params' => [
                 'foo' => [
                     'baz'  => ['bar'],
                     'bam'  => [null, true, false]
                 ]
             ]
         ]);
-        $before = new BeforeEvent(new Transaction($client, $request));
-        $s->onBefore($before);
+
+        /* @var Request $request */
+        $request = $container[0]['request'];
+
         $this->assertTrue($request->hasHeader('Authorization'));
     }
 
@@ -78,30 +89,59 @@ class Oauth1Test extends \PHPUnit_Framework_TestCase
     {
         $config = $this->config;
         $config['signature_method'] = Oauth1::SIGNATURE_METHOD_PLAINTEXT;
-        $s = new Oauth1($config);
-        $client = new Client();
-        $request = $client->createRequest('GET', 'http://httpbin.org', ['auth' => 'oauth']);
-        $before = new BeforeEvent(new Transaction($client, $request));
-        $s->onBefore($before);
+
+        $stack = HandlerStack::create();
+
+        $middleware = new Oauth1($config);
+        $stack->push($middleware);
+
+        $container = [];
+        $history = Middleware::history($container);
+        $stack->push($history);
+
+        $client = new Client([
+            'handler' => $stack
+        ]);
+
+        $client->get('http://httpbin.org', ['auth' => 'oauth']);
+
+        /* @var Request $request */
+        $request = $container[0]['request'];
+
         $this->assertTrue($request->hasHeader('Authorization'));
-        $this->assertContains('oauth_signature_method="PLAINTEXT"', $request->getHeader('Authorization'));
-        $this->assertContains('oauth_signature="', $request->getHeader('Authorization'));
+        $this->assertContains('oauth_signature_method="PLAINTEXT"', $request->getHeader('Authorization')[0]);
+        $this->assertContains('oauth_signature="', $request->getHeader('Authorization')[0]);
     }
 
     public function testSignsOauthRequestsInHeader()
     {
-        $s = new Oauth1($this->config);
-        $client = new Client();
-        $request = $client->createRequest('GET', 'http://httpbin.org', ['auth' => 'oauth']);
-        $before = new BeforeEvent(new Transaction($client, $request));
-        $s->onBefore($before);
+        $stack = HandlerStack::create();
+
+        $middleware = new Oauth1($this->config);
+        $stack->push($middleware);
+
+        $container = [];
+        $history = Middleware::history($container);
+        $stack->push($history);
+
+        $client = new Client([
+            'handler' => $stack
+        ]);
+
+        $client->post('http://httpbin.org/post', [
+            'auth' => 'oauth',
+        ]);
+
+        /* @var Request $request */
+        $request = $container[0]['request'];
+
         $this->assertTrue($request->hasHeader('Authorization'));
-        $this->assertCount(0, $request->getQuery());
+        $this->assertCount(0, \GuzzleHttp\Psr7\parse_query($request->getUri()->getQuery()));
         $check = ['oauth_consumer_key', 'oauth_nonce', 'oauth_signature',
             'oauth_signature_method', 'oauth_timestamp', 'oauth_token',
             'oauth_version'];
         foreach ($check as $name) {
-            $this->assertContains($name . '=', $request->getHeader('Authorization'));
+            $this->assertContains($name . '=', $request->getHeader('Authorization')[0]);
         }
     }
 
@@ -109,32 +149,60 @@ class Oauth1Test extends \PHPUnit_Framework_TestCase
     {
         $config = $this->config;
         $config['request_method'] = Oauth1::REQUEST_METHOD_QUERY;
-        $s = new Oauth1($config);
-        $client = new Client();
-        $request = $client->createRequest('GET', 'http://httpbin.org', ['auth' => 'oauth']);
-        $before = new BeforeEvent(new Transaction($client, $request));
-        $s->onBefore($before);
+
+        $stack = HandlerStack::create();
+
+        $middleware = new Oauth1($config);
+        $stack->push($middleware);
+
+        $container = [];
+        $history = Middleware::history($container);
+        $stack->push($history);
+
+        $client = new Client([
+            'handler' => $stack
+        ]);
+
+        $client->get('http://httpbin.org', ['auth' => 'oauth']);
+
+        /* @var Request $request */
+        $request = $container[0]['request'];
+
         $this->assertFalse($request->hasHeader('Authorization'));
         $check = ['oauth_consumer_key', 'oauth_nonce', 'oauth_signature',
             'oauth_signature_method', 'oauth_timestamp', 'oauth_token',
             'oauth_version'];
         foreach ($check as $name) {
-            $this->assertNotEmpty($request->getQuery()[$name]);
+            $this->assertNotEmpty(\GuzzleHttp\Psr7\parse_query($request->getUri()->getQuery())[$name]);
         }
+
         // Ensure that no extra keys were added
-        $keys = $request->getQuery()->getKeys();
+        $keys = array_keys(\GuzzleHttp\Psr7\parse_query($request->getUri()->getQuery()));
         sort($keys);
         $this->assertSame($keys, $check);
     }
 
     public function testOnlyTouchesWhenAuthConfigIsOauth()
     {
-        $s = new Oauth1($this->config);
-        $client = new Client();
-        $request = $client->createRequest('GET', 'http://httpbin.org');
-        $before = new BeforeEvent(new Transaction($client, $request));
-        $s->onBefore($before);
-        $this->assertCount(0, $request->getQuery());
+        $stack = HandlerStack::create();
+
+        $middleware = new Oauth1($this->config);
+        $stack->push($middleware);
+
+        $container = [];
+        $history = Middleware::history($container);
+        $stack->push($history);
+
+        $client = new Client([
+            'handler' => $stack
+        ]);
+
+        $client->get('http://httpbin.org');
+
+        /* @var Request $request */
+        $request = $container[0]['request'];
+
+        $this->assertCount(0, \GuzzleHttp\Psr7\parse_query($request->getUri()->getQuery()));
         $this->assertEmpty($request->getHeader('Authorization'));
     }
 
@@ -143,15 +211,19 @@ class Oauth1Test extends \PHPUnit_Framework_TestCase
      */
     public function testValidatesRequestMethod()
     {
+        $stack = HandlerStack::create();
+
         $config = $this->config;
         $config['request_method'] = 'Foo';
-        $s = new Oauth1($config);
-        $client = new Client();
-        $before = new BeforeEvent(new Transaction(
-            $client,
-            $client->createRequest('GET', 'http://httpbin.org', ['auth' => 'oauth'])
-        ));
-        $s->onBefore($before);
+
+        $middleware = new Oauth1($config);
+        $stack->push($middleware);
+
+        $client = new Client([
+            'handler' => $stack
+        ]);
+
+        $client->get('http://httpbin.org', ['auth' => 'oauth']);
     }
 
     /**
@@ -159,54 +231,100 @@ class Oauth1Test extends \PHPUnit_Framework_TestCase
      */
     public function testExceptionOnSignatureError()
     {
+        $stack = HandlerStack::create();
+
         $config = $this->config;
         $config['signature_method'] = 'Foo';
-        $s = new Oauth1($config);
-        $client = new Client();
-        $before = new BeforeEvent(new Transaction(
-            $client,
-            $client->createRequest('GET', 'http://httpbin.org', ['auth' => 'oauth'])
-        ));
-        $s->onBefore($before);
+
+        $middleware = new Oauth1($config);
+        $stack->push($middleware);
+
+        $client = new Client([
+            'handler' => $stack
+        ]);
+
+        $client->get('http://httpbin.org', ['auth' => 'oauth']);
     }
 
     public function testDoesNotAddEmptyValuesToAuthorization()
     {
         $config = $this->config;
         unset($config['token']);
-        $s = new Oauth1($config);
-        $client = new Client();
-        $request = $client->createRequest('GET', 'http://httpbin.org', ['auth' => 'oauth']);
-        $before = new BeforeEvent(new Transaction($client, $request));
-        $s->onBefore($before);
+
+        $stack = HandlerStack::create();
+
+        $middleware = new Oauth1($config);
+        $stack->push($middleware);
+
+        $container = [];
+        $history = Middleware::history($container);
+        $stack->push($history);
+
+        $client = new Client([
+            'handler' => $stack
+        ]);
+
+        $client->get('http://httpbin.org', ['auth' => 'oauth']);
+
+        /* @var Request $request */
+        $request = $container[0]['request'];
+
         $this->assertTrue($request->hasHeader('Authorization'));
-        $this->assertNotContains('oauth_token=', $request->getHeader('Authorization'));
+        $this->assertNotContains('oauth_token=', $request->getHeader('Authorization')[0]);
     }
 
     public function testRandomParametersAreNotAutomaticallyAdded()
     {
         $config = $this->config;
         $config['foo'] = 'bar';
-        $s = new Oauth1($config);
-        $client = new Client();
-        $request = $client->createRequest('GET', 'http://httpbin.org', ['auth' => 'oauth']);
-        $before = new BeforeEvent(new Transaction($client, $request));
-        $s->onBefore($before);
+
+        $stack = HandlerStack::create();
+
+        $middleware = new Oauth1($config);
+        $stack->push($middleware);
+
+        $container = [];
+        $history = Middleware::history($container);
+        $stack->push($history);
+
+        $client = new Client([
+            'handler' => $stack
+        ]);
+
+        $client->get('http://httpbin.org', ['auth' => 'oauth']);
+
+        /* @var Request $request */
+        $request = $container[0]['request'];
+
         $this->assertTrue($request->hasHeader('Authorization'));
-        $this->assertNotContains('foo=bar', $request->getHeader('Authorization'));
+        $this->assertNotContains('foo=bar', $request->getHeader('Authorization')[0]);
     }
 
     public function testAllowsRealm()
     {
         $config = $this->config;
         $config['realm'] = 'foo';
-        $s = new Oauth1($config);
-        $client = new Client();
-        $request = $client->createRequest('GET', 'http://httpbin.org', ['auth' => 'oauth']);
-        $before = new BeforeEvent(new Transaction($client, $request));
-        $s->onBefore($before);
+
+        $stack = HandlerStack::create();
+
+        $middleware = new Oauth1($config);
+        $stack->push($middleware);
+
+        $container = [];
+        $history = Middleware::history($container);
+        $stack->push($history);
+
+        $client = new Client([
+            'handler' => $stack
+        ]);
+
+        $client->get('http://httpbin.org', ['auth' => 'oauth']);
+
+        /* @var Request $request */
+        $request = $container[0]['request'];
+
         $this->assertTrue($request->hasHeader('Authorization'));
-        $this->assertContains('OAuth realm="foo",', $request->getHeader('Authorization'));
+        $this->assertContains('OAuth realm="foo",', $request->getHeader('Authorization')[0]);
     }
 
     public function testTwitterIntegration()
@@ -216,22 +334,27 @@ class Oauth1Test extends \PHPUnit_Framework_TestCase
             return;
         }
 
+        $config = $this->config;
+        $config['consumer_key']    = $_SERVER['OAUTH_CONSUMER_KEY'];
+        $config['consumer_secret'] = $_SERVER['OAUTH_CONSUMER_SECRET'];
+        $config['token']           = $_SERVER['OAUTH_TOKEN'];
+        $config['token_secret']    = $_SERVER['OAUTH_TOKEN_SECRET'];
+
+        $stack = HandlerStack::create();
+
+        $middleware = new Oauth1($config);
+        $stack->push($middleware);
+
+        $container = [];
+        $history = Middleware::history($container);
+        $stack->push($history);
+
         $client = new Client([
-            'base_url' => 'https://api.twitter.com/1.1/',
-            'defaults' => ['auth' => 'oauth']
+            'handler' => $stack
         ]);
-
-        $oauth = new Oauth1([
-            'consumer_key'    => $_SERVER['OAUTH_CONSUMER_KEY'],
-            'consumer_secret' => $_SERVER['OAUTH_CONSUMER_SECRET'],
-            'token'           => $_SERVER['OAUTH_TOKEN'],
-            'token_secret'    => $_SERVER['OAUTH_TOKEN_SECRET']
-        ]);
-
-        $client->getEmitter()->attach($oauth);
 
         try {
-            $client->get('account/settings.json');
+            $client->get('https://api.twitter.com/1.1/account/settings.json', ['auth' => 'oauth']);
         } catch (ClientException $e) {
             if ($e->getResponse()->getStatusCode() == 429) {
                 $this->markTestIncomplete('You are being throttled');

--- a/tests/Oauth1Test.php
+++ b/tests/Oauth1Test.php
@@ -21,20 +21,6 @@ class Oauth1Test extends \PHPUnit_Framework_TestCase
         'token_secret'    => 'dracula'
     ];
 
-    public function testFirst()
-    {
-        $stack = HandlerStack::create();
-
-        $middleware = new Oauth1($this->config);
-        $stack->push($middleware);
-
-        $client = new Client([
-            'handler' => $stack
-        ]);
-
-        $request = $client->put('http://requestb.in/1955mwl1', ['auth' => 'oauth', 'body' => '{"testing":"test123"}']);
-    }
-
     public function testAcceptsConfigurationData()
     {
         $p = new Oauth1($this->config);


### PR DESCRIPTION
I changed this plugin to a new Guzzle 6.0 Middleware. All the tests are rewritten for Guzzle 6.0 and the Readme is updated to reflect the changes.

This removes support for Guzzle 4 and 5, so a version number bump would be required to handle the BC break.

Hopefully this PR will be merged.