### PR TITLE
Changed inclusion of body parameter in signature

### DIFF
--- a/src/Oauth1.php
+++ b/src/Oauth1.php
@@ -68,6 +68,7 @@ class Oauth1 implements SubscriberInterface
             'consumer_key'     => 'anonymous',
             'consumer_secret'  => 'anonymous',
             'signature_method' => self::SIGNATURE_METHOD_HMAC,
+            'signature_include_body' => true,
         ], ['signature_method', 'version', 'consumer_key', 'consumer_secret']);
     }
 
@@ -129,7 +130,9 @@ class Oauth1 implements SubscriberInterface
         $body = $request->getBody();
         if ($body instanceof PostBodyInterface && !$body->getFiles()) {
             $query = Query::fromString($body->getFields(true));
-            $params += $query->toArray();
+            if ($this->config['signature_include_body']) {
+                $params += $query->toArray();
+            }
         }
 
         // Parse & add query string parameters as base string parameters


### PR DESCRIPTION
Hi,

I changed the inclusion of body parameters in signature to be optional. I just added a boolean to decide if parameters have to be signed.

For example, I use Java CXF framework to implement a OAuth 1.0a server in my backend and PHP + Guzzle to query this backend and the CXF framework don't sign GET and POST parameters. 

So I think it may be useful to let end user choose if it have to be signed. 

Thank you
