### PR TITLE
#40. Fix signUsingHmacSha1()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "aerendir/oauth-subscriber",
+    "name": "guzzlehttp/oauth-subscriber",
     "description": "Guzzle OAuth 1.0 subscriber",
     "homepage": "http://guzzlephp.org/",
     "keywords": ["oauth", "guzzle"],

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "guzzlehttp/oauth-subscriber",
+    "name": "aerendir/oauth-subscriber",
     "description": "Guzzle OAuth 1.0 subscriber",
     "homepage": "http://guzzlephp.org/",
     "keywords": ["oauth", "guzzle"],

--- a/src/Oauth1.php
+++ b/src/Oauth1.php
@@ -239,8 +239,12 @@ class Oauth1
      */
     private function signUsingHmacSha1($baseString)
     {
-        $key = rawurlencode($this->config['consumer_secret'])
-            . '&' . rawurlencode($this->config['token_secret']);
+        $key = rawurlencode($this->config['consumer_secret']);
+
+        // Add token only if present to avoid wrong encoding due to the superflous ampersand (&)
+        if (isset($this->config['token_secret']) && !empty($this->config['token_secret'])) {
+            $key .= '&' . rawurlencode($this->config['token_secret']);
+        }
 
         return hash_hmac('sha1', $baseString, $key, true);
     }


### PR DESCRIPTION
Add an ` if`statement to avoid the superflous adding of an ampersand (&) if `secret_token` isn't provided/used.

See Issue #40.