### PR TITLE
#40. Fix signUsingHmacSha1()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
-.idea
-.DS_STORE
-coverage
+build
 phpunit.xml
+vendor
 composer.lock
-vendor/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,31 @@
 language: php
 
-php:
-  - 5.5
-  - 5.6
-  - 7.0
-  - hhvm
-
 matrix:
-  allow_failures:
-    - php: hhvm
-    - php: 7.0
-  fast_finish: true
+    include:
+        - php: 5.5
+        - php: 5.6
+        - php: 5.6
+        - php: 7.0
+        - php: hhvm
+
+cache:
+    directories:
+        - $HOME/.composer/cache
 
 install:
-  - travis_retry composer self-update
-  - travis_retry composer install --no-interaction --prefer-source
+    - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction
 
-script: vendor/bin/phpunit
+script:
+    - phpunit --verbose --coverage-clover build/logs/clover.xml
+    - phpenv config-rm xdebug.ini || return 0
+
+after_script:
+  - CODECLIMATE_REPO_TOKEN="8e0cd1566d8bcf657043858efb02e60ac953b34ee1ee4f5a19c5a9f4432c2d73" vendor/bin/test-reporter --stdout > codeclimate.json
+  - "curl -X POST -d @codeclimate.json -H 'Content-Type: application/json' -H 'User-Agent: Code Climate (PHP Test Reporter v0.1.1)' https://codeclimate.com/test_reports"
+
+addons:
+  code_climate:
+    repo_token: 8e0cd1566d8bcf657043858efb02e60ac953b34ee1ee4f5a19c5a9f4432c2d73
+
+after_success:
+    - php vendor/bin/coveralls -v

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ composer.json:
 
     {
         "require": {
-            "guzzlehttp/oauth-subscriber": "0.2.*"
+            "serendipity_hq/guzzle-oauth1-middleware": "~0.3"
         }
     }
 

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,8 @@
+[![Latest Stable Version](https://poser.pugx.org/serendipity_hq/guzzle-oauth1-middleware/v/stable)](https://packagist.org/packages/serendipity_hq/guzzle-oauth1-middleware)
+
+[![Total Downloads](https://poser.pugx.org/serendipity_hq/guzzle-oauth1-middleware/downloads)](https://packagist.org/packages/serendipity_hq/guzzle-oauth1-middleware)
+[![License](https://poser.pugx.org/serendipity_hq/guzzle-oauth1-middleware/license)](https://packagist.org/packages/serendipity_hq/guzzle-oauth1-middleware)
+
 =======================
 Guzzle OAuth Subscriber
 =======================

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,15 @@
 {
-    "name": "guzzlehttp/oauth-subscriber",
-    "description": "Guzzle OAuth 1.0 subscriber",
+    "name": "serendipity_hq/guzzle-oauth1-middleware",
+    "description": "OAuth 1.0a middleware for Guzzle (6+)",
     "homepage": "http://guzzlephp.org/",
     "keywords": ["oauth", "guzzle"],
     "license": "MIT",
     "authors": [
+        {
+            "name": "Adamo Aerendir Crespi",
+            "email": "hello@aerendir.me",
+            "homepage": "http://aerendir.me"
+        },
         {
             "name": "Michael Dowling",
             "email": "mtdowling@gmail.com",
@@ -19,11 +24,6 @@
         "phpunit/phpunit": "~4.0"
     },
     "autoload": {
-        "psr-4": { "GuzzleHttp\\Subscriber\\Oauth\\": "src" }
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "0.3-dev"
-        }
+        "psr-4": { "GuzzleHttp\\Middleware\\": "src" }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "guzzlehttp/guzzle": "~6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0"
+        "phpunit/phpunit": "~4.0",
+        "codeclimate/php-test-reporter": "dev-master"
     },
     "autoload": {
         "psr-4": { "GuzzleHttp\\Middleware\\": "src" }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,4 +18,23 @@
             <directory suffix=".php">src</directory>
         </whitelist>
     </filter>
+    <!--
+    <logging>
+        <log type="coverage-html" target="build/coverage" title="SerendipityHQ Remotes" charset="UTF-8" yui="true" highlight="true"
+             lowUpperBound="35" highLowerBound="70" />
+    </logging>
+
+    <filter>
+        <whitelist addUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src</directory>
+            <exclude>
+                <directory>src/Clerk/Tests</directory>
+                <directory>src/Remotes/Migrator/_old</directory>
+                <directory>src/Remotes/Tests</directory>
+                <directory>src/Tracker/Tests</directory>
+                <directory>src/Tracker/WOOCOMMERCE_2/_old</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+    -->
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,12 +18,14 @@
             <directory suffix=".php">src</directory>
         </whitelist>
     </filter>
-    <!--
     <logging>
-        <log type="coverage-html" target="build/coverage" title="SerendipityHQ Remotes" charset="UTF-8" yui="true" highlight="true"
+        <!--
+        <log type="coverage-html" target="./build/coverage" title="PHP Value Objects Test Suite" charset="UTF-8" yui="true" highlight="true"
              lowUpperBound="35" highLowerBound="70" />
+        -->
+        <log type="coverage-clover" target="build/logs/clover.xml"/>
     </logging>
-
+    <!--
     <filter>
         <whitelist addUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">src</directory>

--- a/src/Oauth1.php
+++ b/src/Oauth1.php
@@ -239,8 +239,11 @@ class Oauth1
      */
     private function signUsingHmacSha1($baseString)
     {
-        $key = rawurlencode($this->config['consumer_secret'])
-            . '&' . rawurlencode($this->config['token_secret']);
+        $key = rawurlencode($this->config['consumer_secret']);
+
+        if (!empty($this->config['token_secret'])) {
+            $key .= '&' . rawurlencode($this->config['token_secret']);
+        }
 
         return hash_hmac('sha1', $baseString, $key, true);
     }

--- a/src/Oauth1.php
+++ b/src/Oauth1.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace GuzzleHttp\Subscriber\Oauth;
+namespace GuzzleHttp\Middleware;
 
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;

--- a/tests/Oauth1Test.php
+++ b/tests/Oauth1Test.php
@@ -7,7 +7,7 @@ use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\Request;
-use GuzzleHttp\Subscriber\Oauth\Oauth1;
+use GuzzleHttp\Middleware\Oauth1;
 
 class Oauth1Test extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
Add an `if`statement to avoid the superflous adding of an ampersand (&) if `secret_token` isn't provided/used.

See Issue #40.