### PR TITLE
Update composer version in readme, 0.3.0 version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ composer.json:
 
     {
         "require": {
-            "guzzlehttp/oauth-subscriber": "0.2.*"
+            "guzzlehttp/oauth-subscriber": "0.3.*"
         }
     }
 


### PR DESCRIPTION
As per issue #43 it seems version 0.3.0 should be the one used with guzzle 6 to avoid a composer version panic.