### PR TITLE
Setting dynamic config #47

### DIFF
--- a/src/Oauth1.php
+++ b/src/Oauth1.php
@@ -66,7 +66,12 @@ class Oauth1
             'consumer_secret'  => 'anonymous',
             'signature_method' => self::SIGNATURE_METHOD_HMAC,
         ];
-
+        
+        $this->set($config);
+    }
+    
+    public function set($config)
+    {
         foreach ($config as $key => $value) {
             $this->config[$key] = $value;
         }

--- a/src/Oauth1.php
+++ b/src/Oauth1.php
@@ -59,6 +59,11 @@ class Oauth1
      */
     public function __construct($config)
     {
+        $this->setConfig($config);
+    }
+
+    public function setConfig($config)
+    {
         $this->config = [
             'version'          => '1.0',
             'request_method'   => self::REQUEST_METHOD_HEADER,
@@ -66,12 +71,7 @@ class Oauth1
             'consumer_secret'  => 'anonymous',
             'signature_method' => self::SIGNATURE_METHOD_HMAC,
         ];
-        
-        $this->set($config);
-    }
-    
-    public function set($config)
-    {
+
         foreach ($config as $key => $value) {
             $this->config[$key] = $value;
         }


### PR DESCRIPTION
Dynamic config allows OAuth1 to be used multiple times.

```php
public function __construct($config)
{
    $this->setConfig($config);
}

public function setConfig($config)
{
    $this->config = [
        'version'          => '1.0',
        'request_method'   => self::REQUEST_METHOD_HEADER,
        'consumer_key'     => 'anonymous',
        'consumer_secret'  => 'anonymous',
        'signature_method' => self::SIGNATURE_METHOD_HMAC,
    ];

    foreach ($config as $key => $value) {
        $this->config[$key] = $value;
    }
}
```