### PR TITLE
Do not require token_secret for 2-legged authentication

### DIFF
--- a/src/Oauth1.php
+++ b/src/Oauth1.php
@@ -239,8 +239,10 @@ class Oauth1
      */
     private function signUsingHmacSha1($baseString)
     {
-        $key = rawurlencode($this->config['consumer_secret'])
-            . '&' . rawurlencode($this->config['token_secret']);
+        $key = rawurlencode($this->config['consumer_secret']) . '&';
+        if (isset($this->config['token_secret'])) {
+            $key .= rawurlencode($this->config['token_secret']);
+        }
 
         return hash_hmac('sha1', $baseString, $key, true);
     }


### PR DESCRIPTION
Fixes the following warning when a request does not set `token` nor `token_secret`:

``` bash
juampy@juampy-box:~/projects/default/oauth_request $ php oauth_request.php 
PHP Notice:  Undefined index: token_secret in /home/juampy/projects/default/oauth_request/vendor/guzzlehttp/oauth-subscriber/src/Oauth1.php on line 244
PHP Stack trace:
PHP   1. {main}() /home/juampy/projects/default/oauth_request/oauth_request.php:0
PHP   2. GuzzleHttp\Client->get() /home/juampy/projects/default/oauth_request/oauth_request.php:23
PHP   3. GuzzleHttp\Client->__call() /home/juampy/projects/default/oauth_request/oauth_request.php:23
PHP   4. GuzzleHttp\Client->request() /home/juampy/projects/default/oauth_request/vendor/guzzlehttp/guzzle/src/Client.php:87
PHP   5. GuzzleHttp\Client->requestAsync() /home/juampy/projects/default/oauth_request/vendor/guzzlehttp/guzzle/src/Client.php:129
PHP   6. GuzzleHttp\Client->transfer() /home/juampy/projects/default/oauth_request/vendor/guzzlehttp/guzzle/src/Client.php:123
PHP   7. GuzzleHttp\HandlerStack->__invoke() /home/juampy/projects/default/oauth_request/vendor/guzzlehttp/guzzle/src/Client.php:268
PHP   8. GuzzleHttp\Middleware::GuzzleHttp\{closure}() /home/juampy/projects/default/oauth_request/vendor/guzzlehttp/guzzle/src/HandlerStack.php:70
PHP   9. GuzzleHttp\RedirectMiddleware->__invoke() /home/juampy/projects/default/oauth_request/vendor/guzzlehttp/guzzle/src/Middleware.php:61
PHP  10. GuzzleHttp\Middleware::GuzzleHttp\{closure}() /home/juampy/projects/default/oauth_request/vendor/guzzlehttp/guzzle/src/RedirectMiddleware.php:68
PHP  11. GuzzleHttp\PrepareBodyMiddleware->__invoke() /home/juampy/projects/default/oauth_request/vendor/guzzlehttp/guzzle/src/Middleware.php:32
PHP  12. GuzzleHttp\Subscriber\Oauth\Oauth1->GuzzleHttp\Subscriber\Oauth\{closure}() /home/juampy/projects/default/oauth_request/vendor/guzzlehttp/guzzle/src/PrepareBodyMiddleware.php:42
PHP  13. GuzzleHttp\Subscriber\Oauth\Oauth1->onBefore() /home/juampy/projects/default/oauth_request/vendor/guzzlehttp/oauth-subscriber/src/Oauth1.php:87
PHP  14. GuzzleHttp\Subscriber\Oauth\Oauth1->getSignature() /home/juampy/projects/default/oauth_request/vendor/guzzlehttp/oauth-subscriber/src/Oauth1.php:101
PHP  15. GuzzleHttp\Subscriber\Oauth\Oauth1->signUsingHmacSha1() /home/juampy/projects/default/oauth_request/vendor/guzzlehttp/oauth-subscriber/src/Oauth1.php:158

Notice: Undefined index: token_secret in /home/juampy/projects/default/oauth_request/vendor/guzzlehttp/oauth-subscriber/src/Oauth1.php on line 244
```
