### PR TITLE
Allow empty token_secret

### DIFF
--- a/src/Oauth1.php
+++ b/src/Oauth1.php
@@ -239,8 +239,11 @@ class Oauth1
      */
     private function signUsingHmacSha1($baseString)
     {
-        $key = rawurlencode($this->config['consumer_secret'])
-            . '&' . rawurlencode($this->config['token_secret']);
+        $key = rawurlencode($this->config['consumer_secret']) . '&';
+
+        if (isset($this->config['token_secret'])) {
+           $key .= rawurlencode($this->config['token_secret']);
+        }
 
         return hash_hmac('sha1', $baseString, $key, true);
     }


### PR DESCRIPTION
Currently, if token_secret is not provided we get an error as we use it in generating signature. Meanwhile, some services (i.e. classlink.com) do not use it.

In this commit we make this configuration parameter optional.