### PR TITLE
Removes unneeded space

### DIFF
--- a/src/Oauth1.php
+++ b/src/Oauth1.php
@@ -299,7 +299,7 @@ class Oauth1
             );
         }
 
-        return ['Authorization', 'OAuth ' . implode(', ', $params)];
+        return ['Authorization', 'OAuth ' . implode(',', $params)];
     }
 
     /**


### PR DESCRIPTION
The (3rd-party) API I have to hit sends a 406 not acceptable if there's a space there on line 302. I think APIs would be less likely complain without it. Postman doesn't put the space there, for example.