### PR TITLE
Make the onBefore() method and $config property protected

### DIFF
--- a/src/Oauth1.php
+++ b/src/Oauth1.php
@@ -33,7 +33,7 @@ class Oauth1
     const SIGNATURE_METHOD_PLAINTEXT = 'PLAINTEXT';
 
     /** @var array Configuration settings */
-    private $config;
+    protected $config;
 
     /**
      * Create a new OAuth 1.0 plugin.
@@ -91,7 +91,14 @@ class Oauth1
         };
     }
 
-    private function onBefore(RequestInterface $request)
+    /**
+     * Modifies the request to add OAuth headers or querystring parameters.
+     *
+     * @param RequestInterface $request Request to authenticate.
+     *
+     * @return RequestInterface
+     */
+    protected function onBefore(RequestInterface $request)
     {
         $oauthparams = $this->getOauthParams(
             $this->generateNonce($request),

--- a/src/Oauth1.php
+++ b/src/Oauth1.php
@@ -293,7 +293,7 @@ class Oauth1
      *
      * @return array
      */
-    private function buildAuthorizationHeader(array $params)
+    protected function buildAuthorizationHeader(array $params)
     {
         foreach ($params as $key => $value) {
             $params[$key] = $key . '="' . rawurlencode($value) . '"';
@@ -317,7 +317,7 @@ class Oauth1
      *
      * @return array
      */
-    private function getOauthParams($nonce, array $config)
+    protected function getOauthParams($nonce, array $config)
     {
         $params = [
             'oauth_consumer_key'     => $config['consumer_key'],


### PR DESCRIPTION
I am dealing with authentication against a third-party service that slightly deviates from the OAuth spec and requires a tweak of the signature base string.

In the rare situations like this where it's necessary to extend the Oauth1 class, this would be made far simpler (requiring less duplication of private methods) by changing the `Oauth1::onBefore` method and `Oauth1::$config` property to be protected instead of private.