### PR TITLE
Use GuzzleHttp build_query instead of http_build_query when creating the baseString

### DIFF
--- a/src/Oauth1.php
+++ b/src/Oauth1.php
@@ -203,7 +203,7 @@ class Oauth1
     {
         // Remove query params from URL. Ref: Spec: 9.1.2.
         $url = $request->getUri()->withQuery('');
-        $query = http_build_query($params, '', '&', PHP_QUERY_RFC3986);
+        $query = \GuzzleHttp\Psr7\build_query($params, PHP_QUERY_RFC3986);
 
         return strtoupper($request->getMethod())
             . '&' . rawurlencode($url)


### PR DESCRIPTION
When sending a request which uses a query containing duplicate parameter keys, the signature is incorrectly generated.

eg. ?parameter=myvalue&paramter=myvalue2

This is being caused by the usage of "http_build_query" instead of the Guzzle "build_query" function in "createBaseString".

---

Closes #69.