### PR TITLE
PHP 8 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
         - php: 7.4
           dist: bionic
         - php: 8.0
-          dist: bionic
+          dist: focal
     fast_finish: true
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ matrix:
           dist: bionic
         - php: 7.4
           dist: bionic
+        - php: 8.0
+          dist: bionic
     fast_finish: true
 
 before_install:

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "guzzlehttp/guzzle": "^6.0|^7.0"
+        "guzzlehttp/guzzle": "^6.0|^7.0",
+        "ext-openssl": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0"

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "ext-openssl": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0"
+        "phpunit/phpunit": "~4.0|^9.3.3"
     },
     "autoload": {
         "psr-4": { "GuzzleHttp\\Subscriber\\Oauth\\": "src" }

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,7 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "guzzlehttp/guzzle": "^6.0|^7.0",
-        "ext-openssl": "*"
+        "guzzlehttp/guzzle": "^6.5|^7.2"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0|^9.3.3"

--- a/src/Oauth1.php
+++ b/src/Oauth1.php
@@ -264,7 +264,7 @@ class Oauth1
 
         $signature = '';
         openssl_sign($baseString, $signature, $privateKey);
-        openssl_free_key($privateKey);
+        unset($privateKey);
 
         return $signature;
     }

--- a/tests/Oauth1Test.php
+++ b/tests/Oauth1Test.php
@@ -317,7 +317,7 @@ class Oauth1Test extends TestCase
     public function testTwitterIntegration()
     {
         if (empty(getenv('OAUTH_CONSUMER_SECRET'))) {
-            $this->markTestSkipped('No OAUTH_CONSphp UMER_SECRET provided in phpunit.xml');
+            $this->markTestSkipped('No OAUTH_CONSUMER_SECRET provided in phpunit.xml');
             return;
         }
 

--- a/tests/Oauth1Test.php
+++ b/tests/Oauth1Test.php
@@ -96,8 +96,8 @@ class Oauth1Test extends TestCase
         $request = $container[0]['request'];
 
         $this->assertTrue($request->hasHeader('Authorization'));
-        $this->assertContains('oauth_signature_method="PLAINTEXT"', $request->getHeader('Authorization')[0]);
-        $this->assertContains('oauth_signature="', $request->getHeader('Authorization')[0]);
+        $this->assertStringContainsString('oauth_signature_method="PLAINTEXT"', $request->getHeader('Authorization')[0]);
+        $this->assertStringContainsString('oauth_signature="', $request->getHeader('Authorization')[0]);
     }
 
     public function testSignsOauthRequestsInHeader()
@@ -128,7 +128,7 @@ class Oauth1Test extends TestCase
             'oauth_signature_method', 'oauth_timestamp', 'oauth_token',
             'oauth_version'];
         foreach ($check as $name) {
-            $this->assertContains($name . '=', $request->getHeader('Authorization')[0]);
+            $this->assertStringContainsString($name . '=', $request->getHeader('Authorization')[0]);
         }
     }
 
@@ -193,11 +193,10 @@ class Oauth1Test extends TestCase
         $this->assertEmpty($request->getHeader('Authorization'));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testValidatesRequestMethod()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $stack = HandlerStack::create();
 
         $config = $this->config;
@@ -213,11 +212,10 @@ class Oauth1Test extends TestCase
         $client->get('http://httpbin.org', ['auth' => 'oauth']);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testExceptionOnSignatureError()
     {
+        $this->expectException(\RuntimeException::class);
+
         $stack = HandlerStack::create();
 
         $config = $this->config;
@@ -257,7 +255,7 @@ class Oauth1Test extends TestCase
         $request = $container[0]['request'];
 
         $this->assertTrue($request->hasHeader('Authorization'));
-        $this->assertNotContains('oauth_token=', $request->getHeader('Authorization')[0]);
+        $this->assertStringNotContainsString('oauth_token=', $request->getHeader('Authorization')[0]);
     }
 
     public function testRandomParametersAreNotAutomaticallyAdded()
@@ -284,7 +282,7 @@ class Oauth1Test extends TestCase
         $request = $container[0]['request'];
 
         $this->assertTrue($request->hasHeader('Authorization'));
-        $this->assertNotContains('foo=bar', $request->getHeader('Authorization')[0]);
+        $this->assertStringNotContainsString('foo=bar', $request->getHeader('Authorization')[0]);
     }
 
     public function testAllowsRealm()
@@ -311,7 +309,7 @@ class Oauth1Test extends TestCase
         $request = $container[0]['request'];
 
         $this->assertTrue($request->hasHeader('Authorization'));
-        $this->assertContains('OAuth realm="foo",', $request->getHeader('Authorization')[0]);
+        $this->assertStringContainsString('OAuth realm="foo",', $request->getHeader('Authorization')[0]);
     }
 
     public function testTwitterIntegration()
@@ -385,7 +383,7 @@ class Oauth1Test extends TestCase
                 'stream' => true
             ]);
             $body = $response->getBody()->getContents();
-            $this->assertContains('bieber', strtolower($body));
+            $this->assertStringContainsString('bieber', strtolower($body));
             $this->assertNotEmpty(json_decode($body, true));
         } catch (ClientException $e) {
             if ($e->getResponse()->getStatusCode() == 429) {

--- a/tests/Oauth1Test.php
+++ b/tests/Oauth1Test.php
@@ -8,8 +8,9 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Subscriber\Oauth\Oauth1;
+use PHPUnit\Framework\TestCase;
 
-class Oauth1Test extends \PHPUnit_Framework_TestCase
+class Oauth1Test extends TestCase
 {
     const TIMESTAMP = '1327274290';
     const NONCE = 'e7aa11195ca58349bec8b5ebe351d3497eb9e603';
@@ -316,7 +317,7 @@ class Oauth1Test extends \PHPUnit_Framework_TestCase
     public function testTwitterIntegration()
     {
         if (empty(getenv('OAUTH_CONSUMER_SECRET'))) {
-            $this->markTestSkipped('No OAUTH_CONSUMER_SECRET provided in phpunit.xml');
+            $this->markTestSkipped('No OAUTH_CONSphp UMER_SECRET provided in phpunit.xml');
             return;
         }
 


### PR DESCRIPTION
PHP 8.0 Deprecated:  Function `openssl_free_key()` is deprecated

https://github.com/php/php-src/blob/07fa13088e1349f4b5a044faeee57f2b34f6b6e4/ext/openssl/openssl.stub.php#L93
https://www.php.net/manual/en/function.openssl-free-key.php