### PR TITLE
fix: support guzzle psr 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "guzzlehttp/guzzle": "^6.5|^7.2"
+        "guzzlehttp/guzzle": "^6.5|^7.2",
+        "guzzlehttp/psr7": "^1.8 || ^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0|^9.3.3"

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=5.5.0",
         "guzzlehttp/guzzle": "^6.5|^7.2",
-        "guzzlehttp/psr7": "^1.8 || ^2.0"
+        "guzzlehttp/psr7": "^1.7|^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0|^9.3.3"

--- a/src/Oauth1.php
+++ b/src/Oauth1.php
@@ -106,7 +106,7 @@ class Oauth1
                 break;
             case self::REQUEST_METHOD_QUERY:
                 $queryParams = Query::parse($request->getUri()->getQuery());
-                $preparedParams = Query::parse($oauthparams + $queryParams);
+                $preparedParams = Query::build($oauthparams + $queryParams);
                 $request = $request->withUri($request->getUri()->withQuery($preparedParams));
                 break;
             default:

--- a/src/Oauth1.php
+++ b/src/Oauth1.php
@@ -2,11 +2,8 @@
 
 namespace GuzzleHttp\Subscriber\Oauth;
 
+use GuzzleHttp\Psr7\Query;
 use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
-use GuzzleHttp\MessageFormatter;
-use GuzzleHttp\Promise;
-use Psr\Http\Message\StreamInterface;
 
 /**
  * OAuth 1.0 signature plugin.
@@ -108,8 +105,8 @@ class Oauth1
                 $request = $request->withHeader($header, $value);
                 break;
             case self::REQUEST_METHOD_QUERY:
-                $queryparams = \GuzzleHttp\Psr7\parse_query($request->getUri()->getQuery());
-                $preparedParams = \GuzzleHttp\Psr7\build_query($oauthparams + $queryparams);
+                $queryParams = Query::parse($request->getUri()->getQuery());
+                $preparedParams = Query::parse($oauthparams + $queryParams);
                 $request = $request->withUri($request->getUri()->withQuery($preparedParams));
                 break;
             default:
@@ -139,14 +136,14 @@ class Oauth1
         unset($params['oauth_signature']);
 
         // Add POST fields if the request uses POST fields and no files
-        if ($request->getHeaderLine('Content-Type') == 'application/x-www-form-urlencoded') {
-            $body = \GuzzleHttp\Psr7\parse_query($request->getBody()->getContents());
+        if ($request->getHeaderLine('Content-Type') === 'application/x-www-form-urlencoded') {
+            $body = Query::parse($request->getBody()->getContents());
             $params += $body;
         }
 
         // Parse & add query string parameters as base string parameters
         $query = $request->getUri()->getQuery();
-        $params += \GuzzleHttp\Psr7\parse_query($query);
+        $params += Query::parse($query);
 
         $baseString = $this->createBaseString(
             $request,

--- a/tests/Oauth1Test.php
+++ b/tests/Oauth1Test.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Query;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Subscriber\Oauth\Oauth1;
 use PHPUnit\Framework\Assert;
@@ -124,7 +125,7 @@ class Oauth1Test extends TestCase
         $request = $container[0]['request'];
 
         $this->assertTrue($request->hasHeader('Authorization'));
-        $this->assertCount(0, \GuzzleHttp\Psr7\parse_query($request->getUri()->getQuery()));
+        $this->assertCount(0, Query::parse($request->getUri()->getQuery()));
         $check = ['oauth_consumer_key', 'oauth_nonce', 'oauth_signature',
             'oauth_signature_method', 'oauth_timestamp', 'oauth_token',
             'oauth_version'];
@@ -161,11 +162,11 @@ class Oauth1Test extends TestCase
             'oauth_signature_method', 'oauth_timestamp', 'oauth_token',
             'oauth_version'];
         foreach ($check as $name) {
-            $this->assertNotEmpty(\GuzzleHttp\Psr7\parse_query($request->getUri()->getQuery())[$name]);
+            $this->assertNotEmpty(Query::parse($request->getUri()->getQuery())[$name]);
         }
 
         // Ensure that no extra keys were added
-        $keys = array_keys(\GuzzleHttp\Psr7\parse_query($request->getUri()->getQuery()));
+        $keys = array_keys(Query::parse($request->getUri()->getQuery()));
         sort($keys);
         $this->assertSame($keys, $check);
     }
@@ -190,7 +191,7 @@ class Oauth1Test extends TestCase
         /* @var Request $request */
         $request = $container[0]['request'];
 
-        $this->assertCount(0, \GuzzleHttp\Psr7\parse_query($request->getUri()->getQuery()));
+        $this->assertCount(0, Query::parse($request->getUri()->getQuery()));
         $this->assertEmpty($request->getHeader('Authorization'));
     }
 


### PR DESCRIPTION
Guzzle PSR7 dropped the functions in the Psr7 namespace in 2.x

This bumps the required version to at least 1.8 or 2.0, both of which have the `Query` class.