### PR TITLE
Fix wrong date format in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,15 @@
 # CHANGELOG
 
-## 0.8.1 - 2025-06-01
+## 0.8.1 - 2025-01-06
 
 * Fixed insufficient nonce entropy (CVE-2025-21617)
 
-## 0.8.0 - 2025-06-01
+## 0.8.0 - 2025-01-06
 
 * Adjusted some method modifiers and added return types
 * Fixed signature generation with duplicate query parameters
 
-## 0.7.0 - 2025-06-01
+## 0.7.0 - 2025-01-06
 
 * Dropped support for HHVM and PHP <7.2.5
 * Dropped support for Guzzle 6.x and PSR-7 1.x


### PR DESCRIPTION
Kind of self-explanatory this one. I was a little confused, looking at my calendar, when trying to figure out the age of the CVE.