### PR TITLE
[0.8] Exclude oauth_signature from signature base string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+* Fixed signature generation when request body or query parameters include `oauth_signature`
+
 ## 0.8.1 - 2025-01-06
 
 * Fixed insufficient nonce entropy (CVE-2025-21617)

--- a/src/Oauth1.php
+++ b/src/Oauth1.php
@@ -135,10 +135,6 @@ class Oauth1
      */
     public function getSignature(RequestInterface $request, array $params): string
     {
-        // Remove oauth_signature if present
-        // Ref: Spec: 9.1.1 ("The oauth_signature parameter MUST be excluded.")
-        unset($params['oauth_signature']);
-
         // Add POST fields if the request uses POST fields and no files
         if ($request->getHeaderLine('Content-Type') === 'application/x-www-form-urlencoded') {
             $body = Query::parse($request->getBody()->getContents());
@@ -148,6 +144,10 @@ class Oauth1
         // Parse & add query string parameters as base string parameters
         $query = $request->getUri()->getQuery();
         $params += Query::parse($query);
+
+        // Remove oauth_signature if present
+        // Ref: Spec: 9.1.1 ("The oauth_signature parameter MUST be excluded.")
+        unset($params['oauth_signature']);
 
         $baseString = $this->createBaseString(
             $request,

--- a/tests/Oauth1Test.php
+++ b/tests/Oauth1Test.php
@@ -75,6 +75,58 @@ class Oauth1Test extends TestCase
         $this->assertTrue($request->hasHeader('Authorization'));
     }
 
+    public function testExcludesOauthSignatureFromFormBodySignature(): void
+    {
+        $oauth = new Oauth1($this->config);
+        $params = [
+            'oauth_consumer_key' => 'foo',
+            'oauth_nonce' => self::NONCE,
+            'oauth_signature_method' => Oauth1::SIGNATURE_METHOD_HMAC,
+            'oauth_timestamp' => self::TIMESTAMP,
+            'oauth_token' => 'count',
+            'oauth_version' => '1.0',
+        ];
+
+        $request = new Request(
+            'POST',
+            'https://httpbin.org/post',
+            ['Content-Type' => 'application/x-www-form-urlencoded'],
+            'foo=bar'
+        );
+        $requestWithSignature = new Request(
+            'POST',
+            'https://httpbin.org/post',
+            ['Content-Type' => 'application/x-www-form-urlencoded'],
+            'foo=bar&oauth_signature=bad'
+        );
+
+        $this->assertSame(
+            $oauth->getSignature($request, $params),
+            $oauth->getSignature($requestWithSignature, $params)
+        );
+    }
+
+    public function testExcludesOauthSignatureFromQuerySignature(): void
+    {
+        $oauth = new Oauth1($this->config);
+        $params = [
+            'oauth_consumer_key' => 'foo',
+            'oauth_nonce' => self::NONCE,
+            'oauth_signature_method' => Oauth1::SIGNATURE_METHOD_HMAC,
+            'oauth_timestamp' => self::TIMESTAMP,
+            'oauth_token' => 'count',
+            'oauth_version' => '1.0',
+        ];
+
+        $request = new Request('GET', 'https://httpbin.org/get?foo=bar');
+        $requestWithSignature = new Request('GET', 'https://httpbin.org/get?foo=bar&oauth_signature=bad');
+
+        $this->assertSame(
+            $oauth->getSignature($request, $params),
+            $oauth->getSignature($requestWithSignature, $params)
+        );
+    }
+
     public function testSignsPlainText(): void
     {
         $config = $this->config;


### PR DESCRIPTION
Exclude oauth_signature after merging form body and query parameters and add regression coverage for oauth_signature in form bodies and query strings.

---

Closes #63.