### PR TITLE
[0.8] Validate RSA private key configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Fixed signature generation when request body or query parameters include `oauth_signature`
+* Validate RSA private key configuration before signing
 
 ## 0.8.1 - 2025-01-06
 

--- a/src/Oauth1.php
+++ b/src/Oauth1.php
@@ -170,7 +170,6 @@ class Oauth1
                 break;
             default:
                 throw new \RuntimeException('Unknown signature method: '.$this->config['signature_method']);
-                break;
         }
 
         return base64_encode($signature);
@@ -228,7 +227,7 @@ class Oauth1
     }
 
     /**
-     * @throws RuntimeException
+     * @throws \RuntimeException
      */
     private function signUsingRsaSha1(string $baseString): string
     {
@@ -236,10 +235,22 @@ class Oauth1
             throw new \RuntimeException('RSA-SHA1 signature method requires the OpenSSL extension.');
         }
 
-        $privateKey = openssl_pkey_get_private(
-            file_get_contents($this->config['private_key_file']),
-            $this->config['private_key_passphrase']
-        );
+        if (!isset($this->config['private_key_file'])
+            || !is_string($this->config['private_key_file'])
+            || $this->config['private_key_file'] === '') {
+            throw new \RuntimeException('RSA-SHA1 signature method requires a private_key_file option.');
+        }
+
+        if (isset($this->config['private_key_passphrase'])) {
+            $privateKey = openssl_pkey_get_private(
+                file_get_contents($this->config['private_key_file']),
+                $this->config['private_key_passphrase']
+            );
+        } else {
+            $privateKey = openssl_pkey_get_private(
+                file_get_contents($this->config['private_key_file'])
+            );
+        }
 
         $signature = '';
         openssl_sign($baseString, $signature, $privateKey);

--- a/tests/Oauth1Test.php
+++ b/tests/Oauth1Test.php
@@ -294,6 +294,63 @@ class Oauth1Test extends TestCase
         $client->get('https://httpbin.org', ['auth' => 'oauth']);
     }
 
+    public function testExceptionOnMissingRsaPrivateKeyFileOption(): void
+    {
+        if (!function_exists('openssl_pkey_get_private')) {
+            $this->markTestSkipped('OpenSSL extension is not available.');
+        }
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('RSA-SHA1 signature method requires a private_key_file option.');
+
+        $config = $this->config;
+        $config['signature_method'] = Oauth1::SIGNATURE_METHOD_RSA;
+
+        $middleware = new Oauth1($config);
+
+        $middleware->getSignature(new Request('GET', 'https://httpbin.org'), []);
+    }
+
+    public function testSignsRsaSha1(): void
+    {
+        if (!function_exists('openssl_pkey_new')) {
+            $this->markTestSkipped('OpenSSL extension is not available.');
+        }
+
+        $privateKey = openssl_pkey_new([
+            'private_key_bits' => 2048,
+            'private_key_type' => OPENSSL_KEYTYPE_RSA,
+        ]);
+        if ($privateKey === false) {
+            $this->markTestSkipped('Unable to generate RSA private key.');
+        }
+
+        $privateKeyContents = '';
+        if (!openssl_pkey_export($privateKey, $privateKeyContents)) {
+            $this->markTestSkipped('Unable to export RSA private key.');
+        }
+
+        $privateKeyFile = tempnam(sys_get_temp_dir(), 'oauth1-key-');
+        $this->assertNotFalse($privateKeyFile);
+
+        $this->assertNotFalse(file_put_contents($privateKeyFile, $privateKeyContents));
+
+        try {
+            $config = $this->config;
+            $config['signature_method'] = Oauth1::SIGNATURE_METHOD_RSA;
+            $config['private_key_file'] = $privateKeyFile;
+
+            $middleware = new Oauth1($config);
+
+            $signature = $middleware->getSignature(new Request('GET', 'https://httpbin.org'), []);
+
+            $this->assertNotSame('', $signature);
+            $this->assertNotFalse(base64_decode($signature, true));
+        } finally {
+            @unlink($privateKeyFile);
+        }
+    }
+
     public function testDoesNotAddEmptyValuesToAuthorization(): void
     {
         $config = $this->config;


### PR DESCRIPTION
## Summary
- Validate the RSA private key file option before signing
- Allow RSA signing without an explicit private key passphrase
- Add RSA signing coverage and a missing-configuration regression test

## Tests
- vendor/bin/phpunit
- php -l src/Oauth1.php
- composer validate --strict --no-check-lock --no-interaction
- git diff --check