### PR TITLE
[0.9] Support per-request OAuth token credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Added support for per-request `token` and `token_secret` overrides
 * Convert RSA signing failures to runtime exceptions
 * Fixed OAuth parameter normalization for duplicate parameter values
+* Made OAuth signature base string generation internal
 * Sign bare query and form parameters as empty values
 
 ## 0.8.2 - 2026-05-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 * Added support for per-request `token` and `token_secret` overrides
 * Convert RSA signing failures to runtime exceptions
 * Fixed OAuth parameter normalization for duplicate parameter values
-* Made OAuth signature base string generation internal
 * Sign bare query and form parameters as empty values
 
 ## 0.8.2 - 2026-05-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Added support for PHP 8.5
+* Added support for per-request `token` and `token_secret` overrides
 * Convert RSA signing failures to runtime exceptions
 * Fixed OAuth parameter normalization for duplicate parameter values
 * Sign bare query and form parameters as empty values

--- a/README.md
+++ b/README.md
@@ -76,6 +76,30 @@ $client = new Client([
 $res = $client->get('statuses/home_timeline.json');
 ```
 
+You can override the `token` and `token_secret` values for an individual
+request using the `oauth` request option. The `auth` request option must
+still be set to `oauth` to enable signing for the request.
+
+```php
+$res = $client->get('statuses/home_timeline.json', [
+    'auth' => 'oauth',
+    'oauth' => [
+        'token'        => 'request_token',
+        'token_secret' => 'request_token_secret',
+    ],
+]);
+```
+
+Only `token` and `token_secret` are supported in the `oauth` request
+option. Pass both values when switching to a different credential pair.
+Do not pass OAuth credentials using Guzzle's array-based `auth` option,
+which is reserved for Guzzle's built-in HTTP authentication handlers. If
+you use custom retry middleware to refresh credentials, make sure retries
+re-enter this middleware so each retry is signed with fresh OAuth
+parameters. Custom middleware that runs before this middleware can still
+see the `oauth` request option, so avoid logging request options that
+contain secrets.
+
 You can set the `token` and `token_secret` options to an empty string to
 use two-legged OAuth.
 

--- a/src/Oauth1.php
+++ b/src/Oauth1.php
@@ -149,7 +149,7 @@ class Oauth1
 
         switch ($config['request_method']) {
             case self::REQUEST_METHOD_HEADER:
-                list($header, $value) = $this->buildAuthorizationHeader($oauthparams, $config);
+                list($header, $value) = self::buildAuthorizationHeader($oauthparams, $config);
                 $request = $request->withHeader($header, $value);
                 break;
             case self::REQUEST_METHOD_QUERY:
@@ -213,16 +213,16 @@ class Oauth1
         // Implements double-dispatch to sign requests
         switch ($config['signature_method']) {
             case Oauth1::SIGNATURE_METHOD_HMAC:
-                $signature = $this->signUsingHmac('sha1', $baseString, $config);
+                $signature = self::signUsingHmac('sha1', $baseString, $config);
                 break;
             case Oauth1::SIGNATURE_METHOD_HMACSHA256:
-                $signature = $this->signUsingHmac('sha256', $baseString, $config);
+                $signature = self::signUsingHmac('sha256', $baseString, $config);
                 break;
             case Oauth1::SIGNATURE_METHOD_RSA:
-                $signature = $this->signUsingRsaSha1($baseString, $config);
+                $signature = self::signUsingRsaSha1($baseString, $config);
                 break;
             case Oauth1::SIGNATURE_METHOD_PLAINTEXT:
-                $signature = $this->signUsingPlaintext($baseString);
+                $signature = self::signUsingPlaintext($baseString);
                 break;
             default:
                 throw new \RuntimeException('Unknown signature method: '.$config['signature_method']);
@@ -305,7 +305,7 @@ class Oauth1
      * @param string $algo   Name of selected hashing algorithm (i.e. "md5", "sha256", "haval160,4", etc..)
      * @param array  $config Configuration settings for this request
      */
-    private function signUsingHmac(string $algo, string $baseString, array $config): string
+    private static function signUsingHmac(string $algo, string $baseString, array $config): string
     {
         $key = rawurlencode($config['consumer_secret']).'&';
         if (isset($config['token_secret'])) {
@@ -320,7 +320,7 @@ class Oauth1
      *
      * @throws \RuntimeException
      */
-    private function signUsingRsaSha1(string $baseString, array $config): string
+    private static function signUsingRsaSha1(string $baseString, array $config): string
     {
         if (!function_exists('openssl_pkey_get_private')) {
             throw new \RuntimeException('RSA-SHA1 signature method requires the OpenSSL extension.');
@@ -362,7 +362,7 @@ class Oauth1
     /**
      * @return string
      */
-    private function signUsingPlaintext(string $baseString)
+    private static function signUsingPlaintext(string $baseString)
     {
         return $baseString;
     }
@@ -373,7 +373,7 @@ class Oauth1
      * @param array $params Associative array of authorization parameters.
      * @param array $config Configuration settings for this request
      */
-    private function buildAuthorizationHeader(array $params, array $config): array
+    private static function buildAuthorizationHeader(array $params, array $config): array
     {
         foreach ($params as $key => $value) {
             $params[$key] = $key.'="'.rawurlencode((string) $value).'"';

--- a/src/Oauth1.php
+++ b/src/Oauth1.php
@@ -87,10 +87,10 @@ class Oauth1
     {
         return function ($request, array $options) use ($handler) {
             if (($options['auth'] ?? null) === 'oauth') {
-                $config = $this->getEffectiveConfig($options);
+                $config = self::getEffectiveConfig($this->config, $options);
                 unset($options['oauth']);
 
-                $request = $this->onBefore($request, $config);
+                $request = self::onBefore($request, $config);
             }
 
             return $handler($request, $options);
@@ -102,14 +102,13 @@ class Oauth1
      *
      * Only token credential overrides are supported in request options.
      *
+     * @param array $config  Base configuration settings
      * @param array $options Request options
      *
      * @throws \InvalidArgumentException
      */
-    private function getEffectiveConfig(array $options): array
+    private static function getEffectiveConfig(array $config, array $options): array
     {
-        $config = $this->config;
-
         if (!array_key_exists('oauth', $options) || $options['oauth'] === null) {
             return $config;
         }
@@ -140,11 +139,11 @@ class Oauth1
      * @throws \InvalidArgumentException
      * @throws \RuntimeException
      */
-    private function onBefore(RequestInterface $request, array $config): RequestInterface
+    private static function onBefore(RequestInterface $request, array $config): RequestInterface
     {
         $oauthparams = self::getOauthParams($config);
 
-        $oauthparams['oauth_signature'] = $this->getSignatureWithConfig($request, $oauthparams, $config);
+        $oauthparams['oauth_signature'] = self::getSignatureWithConfig($request, $oauthparams, $config);
         uksort($oauthparams, 'strcmp');
 
         switch ($config['request_method']) {
@@ -177,7 +176,7 @@ class Oauth1
      */
     public function getSignature(RequestInterface $request, array $params): string
     {
-        return $this->getSignatureWithConfig($request, $params, $this->config);
+        return self::getSignatureWithConfig($request, $params, $this->config);
     }
 
     /**
@@ -189,7 +188,7 @@ class Oauth1
      *
      * @throws \RuntimeException
      */
-    private function getSignatureWithConfig(RequestInterface $request, array $params, array $config): string
+    private static function getSignatureWithConfig(RequestInterface $request, array $params, array $config): string
     {
         // Add POST fields if the request uses POST fields and no files
         if ($request->getHeaderLine('Content-Type') === 'application/x-www-form-urlencoded') {
@@ -205,7 +204,7 @@ class Oauth1
         // Ref: Spec: 9.1.1 ("The oauth_signature parameter MUST be excluded.")
         unset($params['oauth_signature']);
 
-        $baseString = $this->createBaseString(
+        $baseString = self::createBaseString(
             $request,
             self::prepareParameters($params)
         );
@@ -243,7 +242,7 @@ class Oauth1
      *
      * @see https://oauth.net/core/1.0/#sig_base_example
      */
-    protected function createBaseString(RequestInterface $request, array $params): string
+    private static function createBaseString(RequestInterface $request, array $params): string
     {
         // Remove query params from URL. Ref: Spec: 9.1.2.
         return strtoupper($request->getMethod())

--- a/src/Oauth1.php
+++ b/src/Oauth1.php
@@ -86,8 +86,11 @@ class Oauth1
     public function __invoke(callable $handler)
     {
         return function ($request, array $options) use ($handler) {
-            if (isset($options['auth']) && $options['auth'] == 'oauth') {
-                $request = $this->onBefore($request);
+            if (($options['auth'] ?? null) === 'oauth') {
+                $config = $this->getEffectiveConfig($options);
+                unset($options['oauth']);
+
+                $request = $this->onBefore($request, $config);
             }
 
             return $handler($request, $options);
@@ -95,19 +98,58 @@ class Oauth1
     }
 
     /**
+     * Returns the configuration to use for a single request.
+     *
+     * Only token credential overrides are supported in request options.
+     *
+     * @param array $options Request options
+     *
+     * @throws \InvalidArgumentException
+     */
+    private function getEffectiveConfig(array $options): array
+    {
+        $config = $this->config;
+
+        if (!array_key_exists('oauth', $options) || $options['oauth'] === null) {
+            return $config;
+        }
+
+        if (!is_array($options['oauth'])) {
+            throw new \InvalidArgumentException('The oauth request option must be an array.');
+        }
+
+        foreach (['token', 'token_secret'] as $key) {
+            if (!array_key_exists($key, $options['oauth'])) {
+                continue;
+            }
+
+            if ($options['oauth'][$key] === null) {
+                unset($config[$key]);
+                continue;
+            }
+
+            $config[$key] = $options['oauth'][$key];
+        }
+
+        return $config;
+    }
+
+    /**
+     * @param array $config Configuration settings for this request
+     *
      * @throws \InvalidArgumentException
      * @throws \RuntimeException
      */
-    private function onBefore(RequestInterface $request): RequestInterface
+    private function onBefore(RequestInterface $request, array $config): RequestInterface
     {
-        $oauthparams = self::getOauthParams($this->config);
+        $oauthparams = self::getOauthParams($config);
 
-        $oauthparams['oauth_signature'] = $this->getSignature($request, $oauthparams);
+        $oauthparams['oauth_signature'] = $this->getSignatureWithConfig($request, $oauthparams, $config);
         uksort($oauthparams, 'strcmp');
 
-        switch ($this->config['request_method']) {
+        switch ($config['request_method']) {
             case self::REQUEST_METHOD_HEADER:
-                list($header, $value) = $this->buildAuthorizationHeader($oauthparams);
+                list($header, $value) = $this->buildAuthorizationHeader($oauthparams, $config);
                 $request = $request->withHeader($header, $value);
                 break;
             case self::REQUEST_METHOD_QUERY:
@@ -118,7 +160,7 @@ class Oauth1
             default:
                 throw new \InvalidArgumentException(sprintf(
                     'Invalid consumer method "%s"',
-                    $this->config['request_method']
+                    $config['request_method']
                 ));
         }
 
@@ -134,6 +176,20 @@ class Oauth1
      * @throws \RuntimeException
      */
     public function getSignature(RequestInterface $request, array $params): string
+    {
+        return $this->getSignatureWithConfig($request, $params, $this->config);
+    }
+
+    /**
+     * Calculate signature for request using the given configuration.
+     *
+     * @param RequestInterface $request Request to generate a signature for
+     * @param array            $params  Oauth parameters
+     * @param array            $config  Configuration settings for this request
+     *
+     * @throws \RuntimeException
+     */
+    private function getSignatureWithConfig(RequestInterface $request, array $params, array $config): string
     {
         // Add POST fields if the request uses POST fields and no files
         if ($request->getHeaderLine('Content-Type') === 'application/x-www-form-urlencoded') {
@@ -155,21 +211,21 @@ class Oauth1
         );
 
         // Implements double-dispatch to sign requests
-        switch ($this->config['signature_method']) {
+        switch ($config['signature_method']) {
             case Oauth1::SIGNATURE_METHOD_HMAC:
-                $signature = $this->signUsingHmac('sha1', $baseString);
+                $signature = $this->signUsingHmac('sha1', $baseString, $config);
                 break;
             case Oauth1::SIGNATURE_METHOD_HMACSHA256:
-                $signature = $this->signUsingHmac('sha256', $baseString);
+                $signature = $this->signUsingHmac('sha256', $baseString, $config);
                 break;
             case Oauth1::SIGNATURE_METHOD_RSA:
-                $signature = $this->signUsingRsaSha1($baseString);
+                $signature = $this->signUsingRsaSha1($baseString, $config);
                 break;
             case Oauth1::SIGNATURE_METHOD_PLAINTEXT:
                 $signature = $this->signUsingPlaintext($baseString);
                 break;
             default:
-                throw new \RuntimeException('Unknown signature method: '.$this->config['signature_method']);
+                throw new \RuntimeException('Unknown signature method: '.$config['signature_method']);
         }
 
         return base64_encode($signature);
@@ -246,43 +302,46 @@ class Oauth1
     }
 
     /**
-     * @param string $algo Name of selected hashing algorithm (i.e. "md5", "sha256", "haval160,4", etc..)
+     * @param string $algo   Name of selected hashing algorithm (i.e. "md5", "sha256", "haval160,4", etc..)
+     * @param array  $config Configuration settings for this request
      */
-    private function signUsingHmac(string $algo, string $baseString): string
+    private function signUsingHmac(string $algo, string $baseString, array $config): string
     {
-        $key = rawurlencode($this->config['consumer_secret']).'&';
-        if (isset($this->config['token_secret'])) {
-            $key .= rawurlencode($this->config['token_secret']);
+        $key = rawurlencode($config['consumer_secret']).'&';
+        if (isset($config['token_secret'])) {
+            $key .= rawurlencode($config['token_secret']);
         }
 
         return hash_hmac($algo, $baseString, $key, true);
     }
 
     /**
+     * @param array $config Configuration settings for this request
+     *
      * @throws \RuntimeException
      */
-    private function signUsingRsaSha1(string $baseString): string
+    private function signUsingRsaSha1(string $baseString, array $config): string
     {
         if (!function_exists('openssl_pkey_get_private')) {
             throw new \RuntimeException('RSA-SHA1 signature method requires the OpenSSL extension.');
         }
 
-        if (!isset($this->config['private_key_file'])
-            || !is_string($this->config['private_key_file'])
-            || $this->config['private_key_file'] === '') {
+        if (!isset($config['private_key_file'])
+            || !is_string($config['private_key_file'])
+            || $config['private_key_file'] === '') {
             throw new \RuntimeException('RSA-SHA1 signature method requires a private_key_file option.');
         }
 
-        $keyContents = @file_get_contents($this->config['private_key_file']);
+        $keyContents = @file_get_contents($config['private_key_file']);
         if ($keyContents === false) {
             throw new \RuntimeException(sprintf(
                 'Unable to read RSA private key file: %s',
-                $this->config['private_key_file']
+                $config['private_key_file']
             ));
         }
 
-        if (isset($this->config['private_key_passphrase'])) {
-            $privateKey = @openssl_pkey_get_private($keyContents, $this->config['private_key_passphrase']);
+        if (isset($config['private_key_passphrase'])) {
+            $privateKey = @openssl_pkey_get_private($keyContents, $config['private_key_passphrase']);
         } else {
             $privateKey = @openssl_pkey_get_private($keyContents);
         }
@@ -312,17 +371,18 @@ class Oauth1
      * Builds the Authorization header for a request
      *
      * @param array $params Associative array of authorization parameters.
+     * @param array $config Configuration settings for this request
      */
-    private function buildAuthorizationHeader(array $params): array
+    private function buildAuthorizationHeader(array $params, array $config): array
     {
         foreach ($params as $key => $value) {
             $params[$key] = $key.'="'.rawurlencode((string) $value).'"';
         }
 
-        if (isset($this->config['realm'])) {
+        if (isset($config['realm'])) {
             array_unshift(
                 $params,
-                'realm="'.rawurlencode($this->config['realm']).'"'
+                'realm="'.rawurlencode($config['realm']).'"'
             );
         }
 

--- a/tests/Oauth1Test.php
+++ b/tests/Oauth1Test.php
@@ -7,11 +7,14 @@ namespace GuzzleHttp\Tests\Oauth1;
 use GuzzleHttp\Client;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
+use GuzzleHttp\Promise\Create;
 use GuzzleHttp\Psr7\Query;
 use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Subscriber\Oauth\Oauth1;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
 
 class Oauth1Test extends TestCase
 {
@@ -411,6 +414,308 @@ class Oauth1Test extends TestCase
         $this->assertEmpty($request->getHeader('Authorization'));
     }
 
+    public function testOnlyTouchesWhenAuthConfigIsExactlyOauth(): void
+    {
+        $container = [];
+        $client = $this->createClientWithHistory(new Oauth1($this->config), $container);
+
+        $client->get('https://example.com', ['auth' => true]);
+
+        $request = $container[0]['request'];
+
+        $this->assertFalse($request->hasHeader('Authorization'));
+        $this->assertCount(0, Query::parse($request->getUri()->getQuery()));
+    }
+
+    public function testAllowsTokenCredentialsToBeOverriddenPerRequest(): void
+    {
+        $container = [];
+        $client = $this->createClientWithHistory(new Oauth1($this->config), $container);
+
+        $client->get('https://example.com', [
+            'auth' => 'oauth',
+            'oauth' => [
+                'token' => 'override-token',
+                'token_secret' => 'override-secret',
+            ],
+        ]);
+
+        $request = $container[0]['request'];
+        $params = $this->parseAuthorizationHeader($request);
+        $header = $request->getHeaderLine('Authorization');
+
+        $this->assertSame('override-token', $params['oauth_token']);
+        $this->assertThat($header, Assert::logicalNot(Assert::stringContains('override-secret', false)), '');
+        $this->assertThat($header, Assert::logicalNot(Assert::stringContains('token_secret', false)), '');
+    }
+
+    public function testPerRequestTokenSecretChangesSignature(): void
+    {
+        $container = [];
+        $client = $this->createClientWithHistory(new Oauth1($this->config), $container);
+
+        $client->get('https://example.com', [
+            'auth' => 'oauth',
+            'oauth' => [
+                'token' => 'override-token',
+                'token_secret' => 'override-secret',
+            ],
+        ]);
+
+        $request = $container[0]['request'];
+        $params = $this->parseAuthorizationHeader($request);
+        $actualSignature = $params['oauth_signature'];
+        unset($params['oauth_signature']);
+
+        $effectiveConfig = $this->config;
+        $effectiveConfig['token'] = 'override-token';
+        $effectiveConfig['token_secret'] = 'override-secret';
+
+        $constructorSignature = (new Oauth1($this->config))->getSignature(
+            $request->withoutHeader('Authorization'),
+            $params
+        );
+        $effectiveSignature = (new Oauth1($effectiveConfig))->getSignature(
+            $request->withoutHeader('Authorization'),
+            $params
+        );
+
+        $this->assertSame($effectiveSignature, $actualSignature);
+        $this->assertNotSame($constructorSignature, $actualSignature);
+    }
+
+    public function testPerRequestTokenOverridesDoNotMutateMiddlewareConfiguration(): void
+    {
+        $container = [];
+        $client = $this->createClientWithHistory(new Oauth1($this->config), $container);
+
+        $client->get('https://example.com/one', [
+            'auth' => 'oauth',
+            'oauth' => [
+                'token' => 'override-token',
+                'token_secret' => 'override-secret',
+            ],
+        ]);
+        $client->get('https://example.com/two', ['auth' => 'oauth']);
+
+        $firstParams = $this->parseAuthorizationHeader($container[0]['request']);
+        $secondParams = $this->parseAuthorizationHeader($container[1]['request']);
+
+        $this->assertSame('override-token', $firstParams['oauth_token']);
+        $this->assertSame('count', $secondParams['oauth_token']);
+    }
+
+    public function testUsesDefaultOauthRequestOptionFromClientConfiguration(): void
+    {
+        $container = [];
+        $client = $this->createClientWithHistory(new Oauth1($this->config), $container, [
+            'auth' => 'oauth',
+            'oauth' => [
+                'token' => 'default-override-token',
+                'token_secret' => 'default-override-secret',
+            ],
+        ]);
+
+        $client->get('https://example.com');
+
+        $params = $this->parseAuthorizationHeader($container[0]['request']);
+
+        $this->assertSame('default-override-token', $params['oauth_token']);
+    }
+
+    public function testRequestOauthOptionReplacesDefaultOauthRequestOption(): void
+    {
+        $container = [];
+        $client = $this->createClientWithHistory(new Oauth1($this->config), $container, [
+            'auth' => 'oauth',
+            'oauth' => [
+                'token' => 'default-override-token',
+                'token_secret' => 'default-override-secret',
+            ],
+        ]);
+
+        $client->get('https://example.com', [
+            'oauth' => [
+                'token' => 'request-override-token',
+                'token_secret' => 'request-override-secret',
+            ],
+        ]);
+
+        $params = $this->parseAuthorizationHeader($container[0]['request']);
+
+        $this->assertSame('request-override-token', $params['oauth_token']);
+    }
+
+    public function testNullOauthRequestOptionRemovesDefaultOauthRequestOption(): void
+    {
+        $container = [];
+        $client = $this->createClientWithHistory(new Oauth1($this->config), $container, [
+            'auth' => 'oauth',
+            'oauth' => [
+                'token' => 'default-override-token',
+                'token_secret' => 'default-override-secret',
+            ],
+        ]);
+
+        $client->get('https://example.com', ['oauth' => null]);
+
+        $params = $this->parseAuthorizationHeader($container[0]['request']);
+
+        $this->assertSame('count', $params['oauth_token']);
+    }
+
+    public function testOauthRequestOptionDoesNotSignWithoutOauthAuth(): void
+    {
+        $container = [];
+        $client = $this->createClientWithHistory(new Oauth1($this->config), $container);
+
+        $client->get('https://example.com', [
+            'oauth' => [
+                'token' => 'override-token',
+                'token_secret' => 'override-secret',
+            ],
+        ]);
+
+        $request = $container[0]['request'];
+
+        $this->assertFalse($request->hasHeader('Authorization'));
+        $this->assertCount(0, Query::parse($request->getUri()->getQuery()));
+    }
+
+    public function testAuthNullDisablesDefaultOauthAuth(): void
+    {
+        $container = [];
+        $client = $this->createClientWithHistory(new Oauth1($this->config), $container, ['auth' => 'oauth']);
+
+        $client->get('https://example.com', [
+            'auth' => null,
+            'oauth' => [
+                'token' => 'override-token',
+                'token_secret' => 'override-secret',
+            ],
+        ]);
+
+        $request = $container[0]['request'];
+
+        $this->assertFalse($request->hasHeader('Authorization'));
+        $this->assertCount(0, Query::parse($request->getUri()->getQuery()));
+    }
+
+    public function testRejectsNonArrayOauthRequestOption(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The oauth request option must be an array.');
+
+        $container = [];
+        $client = $this->createClientWithHistory(new Oauth1($this->config), $container);
+
+        $client->get('https://example.com', [
+            'auth' => 'oauth',
+            'oauth' => 'override-token',
+        ]);
+    }
+
+    public function testIgnoresUnknownOauthRequestOptions(): void
+    {
+        $container = [];
+        $client = $this->createClientWithHistory(new Oauth1($this->config), $container);
+
+        $client->get('https://example.com', [
+            'auth' => 'oauth',
+            'oauth' => [
+                'token' => 'override-token',
+                'token_secret' => 'override-secret',
+                'foo' => 'bar',
+            ],
+        ]);
+
+        $header = $container[0]['request']->getHeaderLine('Authorization');
+        $params = $this->parseAuthorizationHeader($container[0]['request']);
+
+        $this->assertSame('override-token', $params['oauth_token']);
+        $this->assertThat($header, Assert::logicalNot(Assert::stringContains('foo=', false)), '');
+    }
+
+    public function testNullPerRequestTokenRemovesConfiguredToken(): void
+    {
+        $container = [];
+        $client = $this->createClientWithHistory(new Oauth1($this->config), $container);
+
+        $client->get('https://example.com', [
+            'auth' => 'oauth',
+            'oauth' => [
+                'token' => null,
+                'token_secret' => null,
+            ],
+        ]);
+
+        $header = $container[0]['request']->getHeaderLine('Authorization');
+
+        $this->assertThat($header, Assert::logicalNot(Assert::stringContains('oauth_token=', false)), '');
+        $this->assertThat($header, Assert::stringContains('oauth_signature=', false), '');
+    }
+
+    public function testEmptyPerRequestTokenIsSentAsEmptyString(): void
+    {
+        $container = [];
+        $client = $this->createClientWithHistory(new Oauth1($this->config), $container);
+
+        $client->get('https://example.com', [
+            'auth' => 'oauth',
+            'oauth' => [
+                'token' => '',
+                'token_secret' => '',
+            ],
+        ]);
+
+        $params = $this->parseAuthorizationHeader($container[0]['request']);
+
+        $this->assertSame('', $params['oauth_token']);
+        $this->assertArrayHasKey('oauth_signature', $params);
+    }
+
+    public function testUsesPerRequestTokenInQueryString(): void
+    {
+        $config = $this->config;
+        $config['request_method'] = Oauth1::REQUEST_METHOD_QUERY;
+
+        $container = [];
+        $client = $this->createClientWithHistory(new Oauth1($config), $container);
+
+        $client->get('https://example.com', [
+            'auth' => 'oauth',
+            'oauth' => [
+                'token' => 'override-token',
+                'token_secret' => 'override-secret',
+            ],
+        ]);
+
+        $request = $container[0]['request'];
+        $query = Query::parse($request->getUri()->getQuery());
+
+        $this->assertFalse($request->hasHeader('Authorization'));
+        $this->assertSame('override-token', $query['oauth_token']);
+        $this->assertArrayHasKey('oauth_signature', $query);
+        $this->assertArrayNotHasKey('token_secret', $query);
+        $this->assertArrayNotHasKey('oauth_token_secret', $query);
+    }
+
+    public function testRemovesOauthRequestOptionBeforePassingToHandler(): void
+    {
+        $container = [];
+        $client = $this->createClientWithHistory(new Oauth1($this->config), $container);
+
+        $client->get('https://example.com', [
+            'auth' => 'oauth',
+            'oauth' => [
+                'token' => 'override-token',
+                'token_secret' => 'override-secret',
+            ],
+        ]);
+
+        $this->assertArrayNotHasKey('oauth', $container[0]['options']);
+    }
+
     public function testValidatesRequestMethod(): void
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -666,5 +971,39 @@ class Oauth1Test extends TestCase
         $this->assertTrue($request->hasHeader('Authorization'));
         $this->assertThat($request->getHeader('Authorization')[0], Assert::stringContains('oauth_signature_method="HMAC-SHA256"', false), '');
         $this->assertThat($request->getHeader('Authorization')[0], Assert::stringContains('oauth_signature="', false), '');
+    }
+
+    /**
+     * @param array $container History container populated by Guzzle's history middleware
+     * @param array $config    Additional Guzzle client configuration
+     */
+    private function createClientWithHistory(Oauth1 $middleware, array &$container, array $config = []): Client
+    {
+        $handler = function ($request, array $options) {
+            return Create::promiseFor(new Response(200));
+        };
+        $stack = HandlerStack::create($handler);
+        $stack->push($middleware);
+        $stack->push(Middleware::history($container));
+
+        return new Client(['handler' => $stack] + $config);
+    }
+
+    /**
+     * @return array<string, string> Authorization parameters indexed by parameter name
+     */
+    private function parseAuthorizationHeader(RequestInterface $request): array
+    {
+        $header = $request->getHeaderLine('Authorization');
+        $this->assertSame('OAuth ', substr($header, 0, 6));
+
+        preg_match_all('/([A-Za-z_]+)="([^"]*)"/', $header, $matches, PREG_SET_ORDER);
+
+        $params = [];
+        foreach ($matches as $match) {
+            $params[$match[1]] = rawurldecode($match[2]);
+        }
+
+        return $params;
     }
 }


### PR DESCRIPTION
- Add request-level OAuth token credential overrides via the nested `oauth` request option
- Keep `auth => 'oauth'` as the activation switch and consume `oauth` options before downstream handlers

---

Fixes #62.