### PR TITLE
Update static tooling

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -56,3 +56,20 @@ jobs:
 
       - name: Execute PHP CS Fixer
         run: vendor/bin/php-cs-fixer fix --diff --dry-run
+
+  composer-normalize:
+    name: Composer Normalize
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          coverage: none
+
+      - name: Execute Composer Normalize
+        run: make static-composer-normalize-check

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 .php-cs-fixer.php
 .php-cs-fixer.cache
 .phpunit.result.cache
-/phpstan.neon
-build
 composer.lock
-vendor
-phpunit.xml
+vendor/
+/phpstan.neon
+/phpunit.xml
+
+build/

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,16 @@
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
-	@echo "  start-server                   to start the test server"
-	@echo "  stop-server                    to stop the test server"
-	@echo "  test                           to run tests. Provide TEST to run a specific test."
-	@echo "  static                         to run phpstan and php-cs-fixer on the codebase"
-	@echo "  static-phpstan                 to run phpstan on the codebase"
-	@echo "  static-phpstan-update-baseline to regenerate the phpstan baseline file"
-	@echo "  static-codestyle-fix           to run php-cs-fixer on the codebase, writing changes"
-	@echo "  static-codestyle-check         to run php-cs-fixer on the codebase"
-	@echo "  clean                          to remove build artifacts"
+	@printf "  %-32s %s\n" "start-server" "to start the test server"
+	@printf "  %-32s %s\n" "stop-server" "to stop the test server"
+	@printf "  %-32s %s\n" "test" "to run tests. Provide TEST to run a specific test."
+	@printf "  %-32s %s\n" "static" "to run static checks on the codebase"
+	@printf "  %-32s %s\n" "static-phpstan" "to run phpstan on the codebase"
+	@printf "  %-32s %s\n" "static-phpstan-update-baseline" "to regenerate the phpstan baseline file"
+	@printf "  %-32s %s\n" "static-codestyle-fix" "to run php-cs-fixer on the codebase, writing changes"
+	@printf "  %-32s %s\n" "static-codestyle-check" "to run php-cs-fixer on the codebase"
+	@printf "  %-32s %s\n" "static-composer-normalize-fix" "to run composer-normalize on composer.json, writing changes"
+	@printf "  %-32s %s\n" "static-composer-normalize-check" "to run composer-normalize on composer.json"
+	@printf "  %-32s %s\n" "clean" "to remove build artifacts"
 
 start-server: stop-server
 	node vendor/guzzlehttp/test-server/src/server.js $${OAUTH_SUBSCRIBER_TEST_SERVER_PORT:-8126} &> /dev/null &
@@ -24,7 +26,7 @@ test: start-server
 	vendor/bin/phpunit $(TEST)
 	$(MAKE) stop-server
 
-static: static-phpstan static-codestyle-check
+static: static-phpstan static-codestyle-check static-composer-normalize-check
 
 static-phpstan:
 	composer install
@@ -44,7 +46,15 @@ static-codestyle-fix:
 static-codestyle-check:
 	$(MAKE) static-codestyle-fix CS_PARAMS="--dry-run"
 
+static-composer-normalize-fix:
+	composer install
+	composer bin composer-normalize update
+	composer bin composer-normalize normalize --diff $(COMPOSER_NORMALIZE_PARAMS) ../../composer.json
+
+static-composer-normalize-check:
+	$(MAKE) static-composer-normalize-fix COMPOSER_NORMALIZE_PARAMS="--dry-run"
+
 clean:
 	rm -rf build/artifacts/*
 
-.PHONY: help start-server stop-server test static static-phpstan static-phpstan-update-baseline static-codestyle-fix static-codestyle-check clean
+.PHONY: help start-server stop-server test static static-phpstan static-phpstan-update-baseline static-codestyle-fix static-codestyle-check static-composer-normalize-fix static-composer-normalize-check clean

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,11 @@
 {
     "name": "guzzlehttp/oauth-subscriber",
     "description": "Guzzle OAuth 1.0 subscriber",
-    "keywords": ["oauth", "guzzle"],
     "license": "MIT",
+    "keywords": [
+        "oauth",
+        "guzzle"
+    ],
     "authors": [
         {
             "name": "Graham Campbell",
@@ -26,14 +29,17 @@
         }
     ],
     "require": {
-        "php" : "^7.2.5 || ^8.0",
+        "php": "^7.2.5 || ^8.0",
         "guzzlehttp/guzzle": "^7.10",
         "guzzlehttp/psr7": "^2.8"
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.8.2",
         "guzzlehttp/test-server": "^0.3.2",
-        "phpunit/phpunit" : "^8.5.36 || ^9.6.15"
+        "phpunit/phpunit": "^8.5.52 || ^9.6.34"
+    },
+    "suggest": {
+        "ext-openssl": "Required to sign using RSA-SHA1"
     },
     "autoload": {
         "psr-4": {
@@ -45,20 +51,17 @@
             "GuzzleHttp\\Tests\\Oauth1\\": "tests/"
         }
     },
-    "suggest": {
-        "ext-openssl": "Required to sign using RSA-SHA1"
-    },
-    "extra": {
-        "bamarni-bin": {
-            "bin-links": true,
-            "forward-command": false
-        }
-    },
     "config": {
         "allow-plugins": {
             "bamarni/composer-bin-plugin": true
         },
         "preferred-install": "dist",
         "sort-packages": true
+    },
+    "extra": {
+        "bamarni-bin": {
+            "bin-links": true,
+            "forward-command": false
+        }
     }
 }

--- a/vendor-bin/composer-normalize/composer.json
+++ b/vendor-bin/composer-normalize/composer.json
@@ -1,0 +1,11 @@
+{
+    "require": {
+        "ergebnis/composer-normalize": "2.52.0"
+    },
+    "config": {
+        "allow-plugins": {
+            "ergebnis/composer-normalize": true
+        },
+        "preferred-install": "dist"
+    }
+}

--- a/vendor-bin/php-cs-fixer/composer.json
+++ b/vendor-bin/php-cs-fixer/composer.json
@@ -1,7 +1,7 @@
 {
     "require": {
         "php": "^7.4",
-        "friendsofphp/php-cs-fixer": "^3.95.2"
+        "friendsofphp/php-cs-fixer": "3.95.2"
     },
     "config": {
         "preferred-install": "dist"

--- a/vendor-bin/php-cs-fixer/composer.json
+++ b/vendor-bin/php-cs-fixer/composer.json
@@ -1,7 +1,7 @@
 {
     "require": {
         "php": "^7.4",
-        "friendsofphp/php-cs-fixer": "3.94.2"
+        "friendsofphp/php-cs-fixer": "^3.95.2"
     },
     "config": {
         "preferred-install": "dist"

--- a/vendor-bin/phpstan/composer.json
+++ b/vendor-bin/phpstan/composer.json
@@ -1,8 +1,8 @@
 {
     "require": {
         "php": "^8.2",
-        "phpstan/phpstan": "2.1.40",
-        "phpstan/phpstan-deprecation-rules": "2.0.3"
+        "phpstan/phpstan": "2.1.55",
+        "phpstan/phpstan-deprecation-rules": "2.0.4"
     },
     "config": {
         "preferred-install": "dist"


### PR DESCRIPTION
Updates this repository's static tooling to match the current Guzzle setup. Composer Normalize now runs through the static workflow from Makefile targets, Psalm references are removed, and PHPUnit, PHP-CS-Fixer, PHPStan, and PHPStan deprecation rules are aligned with the shared versions.