### PR TITLE
Prepare 1.0 dependency constraints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.2'
+          php-version: '7.4'
           ini-values: error_reporting=E_ALL
           coverage: 'none'
           extensions: mbstring
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+        php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
 
     steps:
       - name: Set up PHP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 1.0.0 - Unreleased
+
+* Dropped support for PHP 7.2 and 7.3
+* Switched from Guzzle 7.x to 8.x and from Guzzle PSR-7 2.x to 3.x
+
 ## 0.9.0 - 2026-05-19
 
 * Added support for PHP 8.5

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Signs HTTP requests using OAuth 1.0. Requests are signed using a
 consumer key, consumer secret, OAuth token, and OAuth secret.
 
-This version works with Guzzle 7.10+ and PHP 7.2.5+.
+This version works with Guzzle 8.0+ and PHP 7.4+.
 
 ## Installing
 
@@ -13,7 +13,7 @@ This project can be installed using Composer. Add the following to your
 ```json
 {
     "require": {
-        "guzzlehttp/oauth-subscriber": "^0.9"
+        "guzzlehttp/oauth-subscriber": "^1.0"
     }
 }
 ```

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,15 @@
+Guzzle OAuth Subscriber Upgrade Guide
+=====================================
+
+0.9 to 1.0
+----------
+
+#### PHP Version and Dependencies
+
+Guzzle OAuth Subscriber 1.0 requires PHP `^7.4 || ^8.0`, Guzzle `^8.0`, and
+Guzzle PSR-7 `^3.0`. Guzzle OAuth Subscriber 0.9 supported PHP
+`^7.2.5 || ^8.0`, Guzzle `^7.10`, and Guzzle PSR-7 `^2.8`.
+
+If your application still supports PHP 7.2 or 7.3, or still uses Guzzle 7 or
+Guzzle PSR-7 2, continue using Guzzle OAuth Subscriber 0.9 until your minimum
+requirements are raised.

--- a/composer.json
+++ b/composer.json
@@ -29,13 +29,14 @@
         }
     ],
     "require": {
-        "php": "^7.2.5 || ^8.0",
-        "guzzlehttp/guzzle": "^7.10",
-        "guzzlehttp/psr7": "^2.8"
+        "php": "^7.4 || ^8.0",
+        "guzzlehttp/guzzle": "^8.0@dev",
+        "guzzlehttp/psr7": "^3.0@dev"
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.8.2",
-        "guzzlehttp/test-server": "^0.3.2",
+        "guzzlehttp/promises": "^3.0@dev",
+        "guzzlehttp/test-server": "^1.0@dev",
         "phpunit/phpunit": "^8.5.52 || ^9.6.34"
     },
     "suggest": {


### PR DESCRIPTION
This raises the 1.0 branch PHP requirement to PHP ^7.4 || ^8.0, switches the package to Guzzle 8 and Guzzle PSR-7 3 using dev constraints while those releases are still unreleased, and updates the test-server dev dependency to the matching 1.0 line. It also updates CI to start at PHP 7.4, updates the README install example to ^1.0 without `@dev`, adds an upgrade guide, and records the upcoming 1.0.0 dependency changes in the changelog.
