### PR TITLE
Link upgrade guide from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ This project can be installed using Composer. Add the following to your
 }
 ```
 
+## Upgrading
+
+Please see [UPGRADING](UPGRADING.md) for details on upgrading to new major versions.
+
 ## Using the Subscriber
 
 Here's an example showing how to send an authenticated request to the


### PR DESCRIPTION
This adds a README link to the upgrade guide so users can find the 1.0 upgrade notes from the project landing page.

Docs-only change; no tests were run.