### PR TITLE
Clarify OAuth Subscriber 1 upgrade guide

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,11 +4,17 @@ Guzzle OAuth Subscriber Upgrade Guide
 0.9 to 1.0
 ----------
 
+Guzzle OAuth Subscriber 1.0 is a major release that raises the minimum PHP
+version and updates the supported Guzzle dependency stack for Guzzle 8 and
+Guzzle PSR-7 3.x.
+
 #### PHP Version and Dependencies
 
-Guzzle OAuth Subscriber 1.0 requires PHP `^7.4 || ^8.0`, Guzzle `^8.0`, and
-Guzzle PSR-7 `^3.0`. Guzzle OAuth Subscriber 0.9 supported PHP
-`^7.2.5 || ^8.0`, Guzzle `^7.10`, and Guzzle PSR-7 `^2.8`.
+Guzzle OAuth Subscriber 1.0 requires PHP `^7.4 || ^8.0`,
+[Guzzle 8.x](https://github.com/guzzle/guzzle/blob/8.0/UPGRADING.md), and
+[Guzzle PSR-7 3.x](https://github.com/guzzle/psr7/blob/3.0/UPGRADING.md).
+Guzzle OAuth Subscriber 0.9 supported PHP `^7.2.5 || ^8.0`, Guzzle `^7.10`, and
+Guzzle PSR-7 `^2.8`.
 
 If your application still supports PHP 7.2 or 7.3, or still uses Guzzle 7 or
 Guzzle PSR-7 2, continue using Guzzle OAuth Subscriber 0.9 until your minimum


### PR DESCRIPTION
This updates the OAuth Subscriber 1.0 upgrade guide so it starts with a short summary before the PHP and dependency changes. The dependency section now links the Guzzle 8 and PSR-7 3 upgrade guides while keeping the rest of the guide focused on the dependency stack upgrade.