### PR TITLE
Add OAuth middleware return types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Dropped support for PHP 7.2 and 7.3
 * Switched from Guzzle 7.x to 8.x and from Guzzle PSR-7 2.x to 3.x
+* Added native return types to the OAuth middleware entry point
 
 ## 0.9.0 - 2026-05-19
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -19,3 +19,12 @@ Guzzle PSR-7 `^2.8`.
 If your application still supports PHP 7.2 or 7.3, or still uses Guzzle 7 or
 Guzzle PSR-7 2, continue using Guzzle OAuth Subscriber 0.9 until your minimum
 requirements are raised.
+
+#### Native Signatures
+
+`GuzzleHttp\Subscriber\Oauth\Oauth1::__invoke()` now declares a `\Closure`
+return type. Subclasses overriding this method must update their method
+signature to remain compatible.
+
+OAuth middleware handlers are expected to follow Guzzle 8's handler contract and
+return `GuzzleHttp\Promise\PromiseInterface` values.

--- a/src/Oauth1.php
+++ b/src/Oauth1.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GuzzleHttp\Subscriber\Oauth;
 
+use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\Query;
 use Psr\Http\Message\RequestInterface;
 
@@ -78,14 +79,14 @@ class Oauth1
     /**
      * Called when the middleware is handled.
      *
-     * @return \Closure
+     * @param callable(RequestInterface, array): PromiseInterface $handler
      *
      * @throws \InvalidArgumentException
      * @throws \RuntimeException
      */
-    public function __invoke(callable $handler)
+    public function __invoke(callable $handler): \Closure
     {
-        return function ($request, array $options) use ($handler) {
+        return function ($request, array $options) use ($handler): PromiseInterface {
             if (($options['auth'] ?? null) === 'oauth') {
                 $config = self::getEffectiveConfig($this->config, $options);
                 unset($options['oauth']);


### PR DESCRIPTION
This adds native return types to the OAuth middleware entry point and to the middleware closure it returns. It documents the signature alignment for subclasses and keeps the middleware contract consistent with Guzzle 8 handlers.