### PR TITLE
Apply PHP-CS-Fixer config to itself

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 $config = (new PhpCsFixer\Config())
     ->setRiskyAllowed(true)
     ->setRules([
@@ -22,6 +24,7 @@ $config = (new PhpCsFixer\Config())
             ->in(__DIR__.'/src')
             ->in(__DIR__.'/tests')
             ->name('*.php')
+            ->append([__FILE__])
     )
 ;
 


### PR DESCRIPTION
This includes the PHP-CS-Fixer configuration file in the configured finder so style checks cover the config itself. It lets the existing rule set apply consistently to the config file.