### PR TITLE
Improve OAuth middleware typing PHPDoc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Dropped support for PHP 7.2 and 7.3
 * Switched from Guzzle 7.x to 8.x and from Guzzle PSR-7 2.x to 3.x
 * Added native return types to the OAuth middleware entry point
+* Improved PHPDoc for OAuth config arrays and middleware handler contracts
 
 ## 0.9.0 - 2026-05-19
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ Please see [UPGRADING](UPGRADING.md) for details on upgrading to new major versi
 
 ## Using the Subscriber
 
+`GuzzleHttp\Subscriber\Oauth\Oauth1` is invokable Guzzle middleware. It wraps a
+standard Guzzle handler and returns a handler closure with the same contract:
+`callable(Psr\Http\Message\RequestInterface, array<array-key, mixed>): GuzzleHttp\Promise\PromiseInterface<Psr\Http\Message\ResponseInterface, mixed>`.
+
 Here's an example showing how to send an authenticated request to the
 Twitter REST API:
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -28,3 +28,15 @@ signature to remain compatible.
 
 OAuth middleware handlers are expected to follow Guzzle 8's handler contract and
 return `GuzzleHttp\Promise\PromiseInterface` values.
+
+#### Generic Promise And Structured PHPDoc Types
+
+`Oauth1::__invoke()` now documents the standard Guzzle middleware handler
+contract with generic `PromiseInterface<ResponseInterface, mixed>` PHPDoc types.
+This is a static-analysis-only change and does not alter runtime behavior, but
+projects with stricter static analysis may see new or different diagnostics.
+
+`Oauth1::__construct()` config PHPDoc now uses a structured array shape for the
+supported OAuth options. If your project documents reusable OAuth config arrays
+or custom middleware handlers, you may need to update those PHPDoc annotations to
+match the supported option and handler shapes.

--- a/src/Oauth1.php
+++ b/src/Oauth1.php
@@ -7,6 +7,7 @@ namespace GuzzleHttp\Subscriber\Oauth;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\Query;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * OAuth 1.0 signature plugin.
@@ -58,8 +59,24 @@ class Oauth1
      * - realm: OAuth realm.
      * - signature_method: Signature method. One of 'HMAC-SHA1', 'RSA-SHA1',
      *   'HMAC-SHA256', or 'PLAINTEXT'. Defaults to 'HMAC-SHA1'.
+     * - bodyhash: OAuth body hash.
      *
-     * @param array $config Configuration array.
+     * @param array{
+     *     request_method?: 'header'|'query',
+     *     callback?: string,
+     *     consumer_key?: string,
+     *     consumer_secret?: string,
+     *     private_key_file?: string,
+     *     private_key_passphrase?: string,
+     *     token?: string,
+     *     token_secret?: string,
+     *     verifier?: string,
+     *     version?: string,
+     *     realm?: string,
+     *     signature_method?: 'HMAC-SHA1'|'RSA-SHA1'|'HMAC-SHA256'|'PLAINTEXT',
+     *     bodyhash?: string,
+     *     ...
+     * } $config Configuration array.
      */
     public function __construct(array $config)
     {
@@ -79,7 +96,9 @@ class Oauth1
     /**
      * Called when the middleware is handled.
      *
-     * @param callable(RequestInterface, array): PromiseInterface $handler
+     * @param callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed> $handler
+     *
+     * @return \Closure(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>
      *
      * @throws \InvalidArgumentException
      * @throws \RuntimeException

--- a/tests/Oauth1Test.php
+++ b/tests/Oauth1Test.php
@@ -17,6 +17,7 @@ use GuzzleHttp\Subscriber\Oauth\Oauth1;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
 class Oauth1Test extends TestCase
 {
@@ -874,11 +875,17 @@ class Oauth1Test extends TestCase
     }
 
     /**
-     * @param array $container History container populated by Guzzle's history middleware
-     * @param array $config    Additional Guzzle client configuration
+     * @param array<array-key, array{
+     *     request: RequestInterface,
+     *     response: ResponseInterface|null,
+     *     error: mixed,
+     *     options: array<array-key, mixed>
+     * }> $container History container populated by Guzzle's history middleware.
+     * @param array<array-key, mixed> $config Additional Guzzle client configuration.
      */
     private function createClientWithHistory(Oauth1 $middleware, array &$container, array $config = []): Client
     {
+        /** @var callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed> $handler */
         $handler = function (RequestInterface $request, array $options): PromiseInterface {
             return Create::promiseFor(new Response(200));
         };
@@ -890,7 +897,12 @@ class Oauth1Test extends TestCase
     }
 
     /**
-     * @param array $container History container populated by Guzzle's history middleware
+     * @param array<array-key, array{
+     *     request: RequestInterface,
+     *     response: ResponseInterface|null,
+     *     error: mixed,
+     *     options: array<array-key, mixed>
+     * }> $container History container populated by Guzzle's history middleware.
      */
     private function createServerClientWithHistory(Oauth1 $middleware, array &$container): Client
     {


### PR DESCRIPTION
This improves PHPDoc for OAuth configuration arrays and the standard Guzzle middleware handler contract. It also documents the static-analysis impact and mirrors the handler/history shapes in tests.