### PR TITLE
Add plaintext signer return type

### DIFF
--- a/src/Oauth1.php
+++ b/src/Oauth1.php
@@ -378,10 +378,7 @@ class Oauth1
         return $signature;
     }
 
-    /**
-     * @return string
-     */
-    private static function signUsingPlaintext(string $baseString)
+    private static function signUsingPlaintext(string $baseString): string
     {
         return $baseString;
     }


### PR DESCRIPTION
This adds a PHP 7.4-compatible native string return type to the private plaintext signer.