### PR TITLE
Add native property types

### DIFF
--- a/src/Oauth1.php
+++ b/src/Oauth1.php
@@ -36,7 +36,7 @@ class Oauth1
     public const SIGNATURE_METHOD_PLAINTEXT = 'PLAINTEXT';
 
     /** @var array Configuration settings */
-    private $config;
+    private array $config;
 
     /**
      * Create a new OAuth 1.0 plugin.


### PR DESCRIPTION
Adds a PHP 7.4-compatible native property type to the OAuth middleware configuration property, matching the constructor-initialized array state.