### PR TITLE
Reject native PHP serialization of Oauth1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Dropped support for PHP 7.2 and 7.3
 * Switched from Guzzle 7.x to 8.x and from Guzzle PSR-7 2.x to 3.x
+* Reject native PHP serialization of `Oauth1`
 * Added native return types to the OAuth middleware entry point
 * Improved PHPDoc for OAuth config arrays and middleware handler contracts
 

--- a/src/Oauth1.php
+++ b/src/Oauth1.php
@@ -93,6 +93,16 @@ class Oauth1
         }
     }
 
+    public function __serialize(): array
+    {
+        throw new \LogicException(self::class.' should never be serialized');
+    }
+
+    public function __unserialize(array $data): void
+    {
+        throw new \LogicException(self::class.' should never be unserialized');
+    }
+
     /**
      * Called when the middleware is handled.
      *


### PR DESCRIPTION
This rejects native PHP serialization for Oauth1 and documents the new behavior.