### PR TITLE
Fix non-finite float coercion warnings on PHP 8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.9.2 - Upcoming
+
+* Fixed non-finite float values emitting coercion warnings on PHP 8.5
+
 ## 0.9.1 - 2026-06-02
 
 * Require `guzzlehttp/guzzle` ^7.11, `guzzlehttp/psr7` ^2.11

--- a/src/Oauth1.php
+++ b/src/Oauth1.php
@@ -269,6 +269,8 @@ class Oauth1
                 foreach ($value as $index => $nestedValue) {
                     if ($nestedValue === null) {
                         $data[$key][$index] = '';
+                    } else {
+                        $data[$key][$index] = self::normalizeNonFiniteFloat($nestedValue);
                     }
                 }
 
@@ -278,7 +280,11 @@ class Oauth1
                         self::encodeParameterValue($right)
                     );
                 });
+
+                continue;
             }
+
+            $data[$key] = self::normalizeNonFiniteFloat($value);
         }
 
         return $data;
@@ -297,7 +303,24 @@ class Oauth1
             $value = (int) $value;
         }
 
-        return rawurlencode((string) $value);
+        return rawurlencode((string) self::normalizeNonFiniteFloat($value));
+    }
+
+    /**
+     * Converts non-finite floats to the strings PHP coerces them to, as
+     * implicit coercion of NAN emits a warning on PHP 8.5.
+     *
+     * @param mixed $value Parameter value
+     *
+     * @return mixed
+     */
+    private static function normalizeNonFiniteFloat($value)
+    {
+        if (is_float($value) && !is_finite($value)) {
+            return is_nan($value) ? 'NAN' : ($value > 0 ? 'INF' : '-INF');
+        }
+
+        return $value;
     }
 
     /**
@@ -375,7 +398,7 @@ class Oauth1
     private static function buildAuthorizationHeader(array $params, array $config): array
     {
         foreach ($params as $key => $value) {
-            $params[$key] = $key.'="'.rawurlencode((string) $value).'"';
+            $params[$key] = $key.'="'.rawurlencode((string) self::normalizeNonFiniteFloat($value)).'"';
         }
 
         if (isset($config['realm'])) {
@@ -419,6 +442,6 @@ class Oauth1
             }
         }
 
-        return $params;
+        return array_map([self::class, 'normalizeNonFiniteFloat'], $params);
     }
 }


### PR DESCRIPTION
PHP 8.5 emits a warning whenever a NAN float is implicitly coerced to a string. OAuth parameter values are coerced to strings when the Authorization header is built, when parameters are prepared and encoded for the signature base string, and when query string signing rebuilds the query, so a non-finite float value now triggers the warning at each of these sites. This converts non-finite floats to their string forms explicitly beforehand, preserving the existing signatures and output on all PHP versions.