### PR TITLE
Reject non-finite float values in OAuth parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Dropped support for PHP 7.2 and 7.3
 * Switched from Guzzle 7.x to 8.x and from Guzzle PSR-7 2.x to 3.x
 * Reject native PHP serialization of `Oauth1`
+* Reject non-finite float values in OAuth parameters
 * Added native return types to the OAuth middleware entry point
 * Improved PHPDoc for OAuth config arrays and middleware handler contracts
 

--- a/src/Oauth1.php
+++ b/src/Oauth1.php
@@ -300,7 +300,7 @@ class Oauth1
                     if ($nestedValue === null) {
                         $data[$key][$index] = '';
                     } else {
-                        $data[$key][$index] = self::normalizeNonFiniteFloat($nestedValue);
+                        self::assertFiniteFloat($nestedValue);
                     }
                 }
 
@@ -314,7 +314,7 @@ class Oauth1
                 continue;
             }
 
-            $data[$key] = self::normalizeNonFiniteFloat($value);
+            self::assertFiniteFloat($value);
         }
 
         return $data;
@@ -333,24 +333,19 @@ class Oauth1
             $value = (int) $value;
         }
 
-        return rawurlencode((string) self::normalizeNonFiniteFloat($value));
+        self::assertFiniteFloat($value);
+
+        return rawurlencode((string) $value);
     }
 
     /**
-     * Converts non-finite floats to the strings PHP coerces them to, as
-     * implicit coercion of NAN emits a warning on PHP 8.5.
-     *
      * @param mixed $value Parameter value
-     *
-     * @return mixed
      */
-    private static function normalizeNonFiniteFloat($value)
+    private static function assertFiniteFloat($value): void
     {
         if (is_float($value) && !is_finite($value)) {
-            return is_nan($value) ? 'NAN' : ($value > 0 ? 'INF' : '-INF');
+            throw new \InvalidArgumentException('Non-finite floats are not supported in OAuth parameters.');
         }
-
-        return $value;
     }
 
     /**
@@ -425,7 +420,8 @@ class Oauth1
     private static function buildAuthorizationHeader(array $params, array $config): array
     {
         foreach ($params as $key => $value) {
-            $params[$key] = $key.'="'.rawurlencode((string) self::normalizeNonFiniteFloat($value)).'"';
+            self::assertFiniteFloat($value);
+            $params[$key] = $key.'="'.rawurlencode((string) $value).'"';
         }
 
         if (isset($config['realm'])) {
@@ -469,6 +465,10 @@ class Oauth1
             }
         }
 
-        return array_map([self::class, 'normalizeNonFiniteFloat'], $params);
+        foreach ($params as $value) {
+            self::assertFiniteFloat($value);
+        }
+
+        return $params;
     }
 }

--- a/tests/Oauth1Test.php
+++ b/tests/Oauth1Test.php
@@ -75,6 +75,27 @@ class Oauth1Test extends TestCase
         $this->assertTrue($request->hasHeader('Authorization'));
     }
 
+    /**
+     * @dataProvider nonFiniteFloatProvider
+     */
+    public function testRejectsNonFiniteFloatParameters(float $value): void
+    {
+        $oauth = new Oauth1($this->config);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Non-finite floats are not supported in OAuth parameters.');
+        $oauth->getSignature(new Request('POST', 'http://example.com/'), ['score' => $value]);
+    }
+
+    public static function nonFiniteFloatProvider(): array
+    {
+        return [
+            'NAN' => [\NAN],
+            'INF' => [\INF],
+            '-INF' => [-\INF],
+        ];
+    }
+
     public function testExcludesOauthSignatureFromFormBodySignature(): void
     {
         $oauth = new Oauth1($this->config);


### PR DESCRIPTION
Non-finite float values in OAuth parameters now throw an `InvalidArgumentException` instead of being coerced to strings, replacing the explicit conversion added in 0.9. They cannot produce a valid signature, so rejecting them surfaces the mistake instead of signing a request with a literal NAN or INF. Finite floats continue to be signed as before.