### PR TITLE
Freeze trim characters ahead of PHP 8.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.9.4 - Unreleased
+
+* Pass explicit trim characters ahead of the PHP 8.6 trim default change
+
 ## 0.9.3 - 2026-06-23
 
 * Require `guzzlehttp/guzzle` ^7.12.3 and `guzzlehttp/psr7` ^2.12.3

--- a/src/Oauth1.php
+++ b/src/Oauth1.php
@@ -192,7 +192,7 @@ class Oauth1
     {
         // Add POST fields if the request uses POST fields and no files
         $contentType = $request->getHeaderLine('Content-Type');
-        $mediaType = strtolower(trim(explode(';', $contentType, 2)[0]));
+        $mediaType = strtolower(trim(explode(';', $contentType, 2)[0], " \n\r\t\0\x0B"));
 
         if ($mediaType === 'application/x-www-form-urlencoded') {
             $body = Query::parse($request->getBody()->getContents());


### PR DESCRIPTION
PHP 8.6 adds the form feed character to the default `$characters` set of `trim`, so the `Content-Type` media-type extraction used for form body signing, the one call in this package relying on the default, would change behavior there. This change passes the pre-8.6 set explicitly, keeping behavior identical on every PHP version. This is the oauth-subscriber counterpart of guzzle/guzzle#3775.
