### PR TITLE
Trim media types with HTTP optional whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Reject non-finite float values in OAuth parameters
 * Added native return types to the OAuth middleware entry point
 * Improved PHPDoc for OAuth config arrays and middleware handler contracts
+* Trim `Content-Type` media types with HTTP optional whitespace when signing
 
 ## 0.9.3 - 2026-06-23
 

--- a/src/Oauth1.php
+++ b/src/Oauth1.php
@@ -222,7 +222,7 @@ class Oauth1
     {
         // Add POST fields if the request uses POST fields and no files
         $contentType = $request->getHeaderLine('Content-Type');
-        $mediaType = strtolower(trim(explode(';', $contentType, 2)[0]));
+        $mediaType = strtolower(trim(explode(';', $contentType, 2)[0], " \t"));
 
         if ($mediaType === 'application/x-www-form-urlencoded') {
             $body = Query::parse($request->getBody()->getContents());


### PR DESCRIPTION
This is the 1.0 counterpart of the 0.9 trim explicitness change. Instead of freezing the pre-8.6 PHP default set, the `Content-Type` media-type extraction used for form body signing now trims with HTTP optional whitespace, space and horizontal tab, matching RFC 9110 field parsing. Validated PSR-7 header values cannot carry the no-longer-trimmed control bytes, so this is not observable through supported inputs, and it keeps the trim independent of the PHP 8.6 default change.
