### PR TITLE
Use late static binding in serialization refusal messages

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -29,6 +29,12 @@ signature to remain compatible.
 OAuth middleware handlers are expected to follow Guzzle 8's handler contract and
 return `GuzzleHttp\Promise\PromiseInterface` values.
 
+#### Native PHP Serialization
+
+`Oauth1` no longer supports native PHP `serialize()` or `unserialize()`.
+Persist OAuth configuration values and create a new middleware instance instead
+of persisting runtime middleware objects.
+
 #### Generic Promise and Structured PHPDoc Types
 
 `Oauth1::__invoke()` now documents the standard Guzzle middleware handler

--- a/src/Oauth1.php
+++ b/src/Oauth1.php
@@ -95,12 +95,12 @@ class Oauth1
 
     public function __serialize(): array
     {
-        throw new \LogicException(self::class.' should never be serialized');
+        throw new \LogicException(static::class.' should never be serialized');
     }
 
     public function __unserialize(array $data): void
     {
-        throw new \LogicException(self::class.' should never be unserialized');
+        throw new \LogicException(static::class.' should never be unserialized');
     }
 
     /**

--- a/tests/Oauth1Test.php
+++ b/tests/Oauth1Test.php
@@ -54,6 +54,24 @@ class Oauth1Test extends TestCase
         $this->assertEquals('header', $config['request_method']);
     }
 
+    public function testRejectsNativePhpSerializationWithRuntimeClassName(): void
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage(Oauth1SerializationTestDouble::class.' should never be serialized');
+
+        serialize(new Oauth1SerializationTestDouble($this->config));
+    }
+
+    public function testRejectsNativePhpUnserializationWithRuntimeClassName(): void
+    {
+        $class = Oauth1SerializationTestDouble::class;
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage($class.' should never be unserialized');
+
+        unserialize(sprintf('O:%d:"%s":0:{}', strlen($class), $class));
+    }
+
     public function testCreatesStringToSignFromPostRequest(): void
     {
         $container = [];
@@ -991,4 +1009,8 @@ class Oauth1Test extends TestCase
 
         return $params;
     }
+}
+
+final class Oauth1SerializationTestDouble extends Oauth1
+{
 }


### PR DESCRIPTION
`Oauth1` is not final, but its serialization refusal messages were built with `self::class`, so a subclass was rejected with a message naming `GuzzleHttp\Subscriber\Oauth\Oauth1` rather than the runtime class. The magic methods now use `static::class`, which keeps the exception type and reject-only behavior identical for base instances while reporting the actual subclass name. Since this hardening was advertised in the 1.0 changelog but never covered by tests or the upgrade guide, this also adds tests pinning both the `serialize()` and `unserialize()` refusal paths through a named subclass fixture and documents the rejection in a new Native PHP Serialization section of `UPGRADING.md`.