### PR TITLE
Document non-finite float rejection and throws contract

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -35,6 +35,12 @@ return `GuzzleHttp\Promise\PromiseInterface` values.
 Persist OAuth configuration values and create a new middleware instance instead
 of persisting runtime middleware objects.
 
+#### Non-Finite Float OAuth Parameters
+
+OAuth parameter values containing `NAN`, `INF`, or `-INF` now throw an
+`\InvalidArgumentException` during signature generation. Convert these
+values to finite strings or omit them before they enter OAuth parameters.
+
 #### Generic Promise and Structured PHPDoc Types
 
 `Oauth1::__invoke()` now documents the standard Guzzle middleware handler
@@ -44,5 +50,5 @@ projects with stricter static analysis may see new or different diagnostics.
 
 `Oauth1::__construct()` config PHPDoc now uses a structured array shape for the
 supported OAuth options. If your project documents reusable OAuth config arrays
-or custom middleware handlers, you may need to update those PHPDoc annotations to
-match the supported option and handler shapes.
+or custom middleware handlers, you may need to update those PHPDoc annotations
+to match the supported option and handler shapes.

--- a/src/Oauth1.php
+++ b/src/Oauth1.php
@@ -202,6 +202,7 @@ class Oauth1
      * @param RequestInterface $request Request to generate a signature for
      * @param array            $params  Oauth parameters.
      *
+     * @throws \InvalidArgumentException If OAuth parameters contain non-finite floats.
      * @throws \RuntimeException
      */
     public function getSignature(RequestInterface $request, array $params): string
@@ -216,6 +217,7 @@ class Oauth1
      * @param array            $params  Oauth parameters
      * @param array            $config  Configuration settings for this request
      *
+     * @throws \InvalidArgumentException If OAuth parameters contain non-finite floats.
      * @throws \RuntimeException
      */
     private static function getSignatureWithConfig(RequestInterface $request, array $params, array $config): string


### PR DESCRIPTION
Users upgrading to 1.0 need to know that OAuth parameter values containing `NAN`, `INF`, or `-INF` now fail fast during signature generation, but the upgrade guide has no section for the rejection and the signature methods' PHPDoc lists only `@throws \RuntimeException`. This adds `@throws \InvalidArgumentException` to `getSignature()` and `getSignatureWithConfig()` so callers and static analysis tooling do not under-handle the deliberate exception, documents the rejection in a new Non-Finite Float OAuth Parameters section of `UPGRADING.md` after the other runtime-behavior sections, and rewraps the one overlong line in the guide while the file is being edited. The behavior itself is already implemented and covered by the existing non-finite float tests, so no runtime or test changes are included.