### PR TITLE
Cover Content-Type optional whitespace signing

### DIFF
--- a/tests/Oauth1Test.php
+++ b/tests/Oauth1Test.php
@@ -176,10 +176,17 @@ class Oauth1Test extends TestCase
             ['Content-Type' => 'APPLICATION/X-WWW-FORM-URLENCODED; charset=UTF-8'],
             'foo=bar'
         );
+        $ows = new Request(
+            'POST',
+            'https://httpbin.org/post',
+            ['Content-Type' => "application/x-www-form-urlencoded \t; charset=UTF-8"],
+            'foo=bar'
+        );
 
         $this->assertSame($expected, $oauth->getSignature($exact, $params));
         $this->assertSame($expected, $oauth->getSignature($parameterized, $params));
         $this->assertSame($expected, $oauth->getSignature($uppercase, $params));
+        $this->assertSame($expected, $oauth->getSignature($ows, $params));
     }
 
     public function testSignsBareFormBodyParametersAsEmptyValues(): void


### PR DESCRIPTION
`Oauth1` trims HTTP optional whitespace around the parsed `Content-Type` media type before deciding whether to sign form body parameters, and the 1.0 changelog advertises that behavior, but the existing signing test covers only exact, parameterized, and uppercase media types with no SP or HTAB adjacent to the media type. If the trim were removed or narrowed, a valid whitespace-padded parameterized `Content-Type` would silently stop signing form body parameters and change OAuth signatures while the suite still passed. This adds one request variant with a space and a tab before the parameter separator to `testSignsParameterizedFormContentType()` and asserts it produces the same signature as the other valid form variants. The whitespace sits before the semicolon because PSR-7 already trims field-edge whitespace, so inner OWS is the stable way to exercise the trim.