### PR TITLE
Wrap documentation prose to 80 columns

### DIFF
--- a/docs/oauth-1-0-middleware-usage.md
+++ b/docs/oauth-1-0-middleware-usage.md
@@ -1,18 +1,29 @@
 # OAuth 1.0 Middleware Usage
 
-`GuzzleHttp\Subscriber\Oauth\Oauth1` signs outgoing Guzzle requests with OAuth 1.0 credentials. This page covers the middleware setup, request options, credential overrides, signature methods, and retry considerations for this package.
+`GuzzleHttp\Subscriber\Oauth\Oauth1` signs outgoing Guzzle requests with OAuth
+1.0 credentials. This page covers the middleware setup, request options,
+credential overrides, signature methods, and retry considerations for this
+package.
 
-Use this package for APIs that require OAuth 1.0 request signing. It does not implement an OAuth 2.0 authorization flow or bearer-token client.
+Use this package for APIs that require OAuth 1.0 request signing. It does not
+implement an OAuth 2.0 authorization flow or bearer-token client.
 
 ## OAuth 1.0 vs OAuth 2.0
 
-OAuth 1.0 signs each HTTP request with a consumer key, consumer secret, optional token credentials, nonce, timestamp, and signature. `Oauth1` adds those OAuth parameters to the `Authorization` header by default, or to the query string when configured to do so.
+OAuth 1.0 signs each HTTP request with a consumer key, consumer secret, optional
+token credentials, nonce, timestamp, and signature. `Oauth1` adds those OAuth
+parameters to the `Authorization` header by default, or to the query string when
+configured to do so.
 
-OAuth 2.0 bearer-token APIs usually do not need this package. For those APIs, send the bearer token using normal Guzzle request options, for example `['headers' => ['Authorization' => 'Bearer ...']]`.
+OAuth 2.0 bearer-token APIs usually do not need this package. For those APIs,
+send the bearer token using normal Guzzle request options, for example
+`['headers' => ['Authorization' => 'Bearer ...']]`.
 
 ## Attaching Middleware
 
-`Oauth1` is invokable [Guzzle middleware](https://github.com/guzzle/guzzle/blob/8.0/docs/middleware.md). Push it onto the client handler stack before sending signed requests:
+`Oauth1` is invokable
+[Guzzle middleware](https://github.com/guzzle/guzzle/blob/8.0/docs/middleware.md).
+Push it onto the client handler stack before sending signed requests:
 
 ```php
 use GuzzleHttp\Client;
@@ -39,7 +50,9 @@ $response = $client->get('resource', ['auth' => 'oauth']);
 
 ## Signing Requests
 
-The OAuth middleware only signs a request when the Guzzle [`auth` request option](https://github.com/guzzle/guzzle/blob/8.0/docs/request-options.md#auth) is exactly `oauth`.
+The OAuth middleware only signs a request when the Guzzle
+[`auth` request option](https://github.com/guzzle/guzzle/blob/8.0/docs/request-options.md#auth)
+is exactly `oauth`.
 
 ```php
 $response = $client->post('resource', [
@@ -50,9 +63,13 @@ $response = $client->post('resource', [
 ]);
 ```
 
-Do not pass OAuth credentials using Guzzle's array-based `auth` option. Array-based `auth` is reserved for Guzzle's built-in HTTP authentication handlers.
+Do not pass OAuth credentials using Guzzle's array-based `auth` option.
+Array-based `auth` is reserved for Guzzle's built-in HTTP authentication
+handlers.
 
-By default, OAuth parameters are sent in the `Authorization` header. Set `request_method` to `Oauth1::REQUEST_METHOD_QUERY` to add OAuth parameters to the query string instead.
+By default, OAuth parameters are sent in the `Authorization` header. Set
+`request_method` to `Oauth1::REQUEST_METHOD_QUERY` to add OAuth parameters to
+the query string instead.
 
 ```php
 $middleware = new Oauth1([
@@ -66,7 +83,8 @@ $middleware = new Oauth1([
 
 ## Client Default Auth
 
-You can set `auth` to `oauth` as a client default when every request sent by that client should be signed.
+You can set `auth` to `oauth` as a client default when every request sent by
+that client should be signed.
 
 ```php
 use GuzzleHttp\Client;
@@ -92,7 +110,8 @@ $client = new Client([
 $response = $client->get('resource');
 ```
 
-Set `auth` to `null` on an individual request to disable a client default `auth => oauth` value for that request.
+Set `auth` to `null` on an individual request to disable a client default `auth
+=> oauth` value for that request.
 
 ```php
 $response = $client->get('public-resource', ['auth' => null]);
@@ -100,7 +119,9 @@ $response = $client->get('public-resource', ['auth' => null]);
 
 ## Per-Request Credentials
 
-You can override `token` and `token_secret` for an individual request using the `oauth` request option. The request must still use `auth => oauth` directly or through a client default.
+You can override `token` and `token_secret` for an individual request using the
+`oauth` request option. The request must still use `auth => oauth` directly or
+through a client default.
 
 ```php
 $response = $client->get('resource', [
@@ -112,15 +133,24 @@ $response = $client->get('resource', [
 ]);
 ```
 
-Only `token` and `token_secret` are supported in the per-request `oauth` option. Unknown `oauth` keys are ignored. Pass both values when switching to a different credential pair because `token_secret` affects the signature but is never sent as an OAuth parameter.
+Only `token` and `token_secret` are supported in the per-request `oauth` option.
+Unknown `oauth` keys are ignored. Pass both values when switching to a different
+credential pair because `token_secret` affects the signature but is never sent
+as an OAuth parameter.
 
-Client default request options are honored. If a client has a default `oauth` array, a request-level `oauth` array replaces that default array. Set request `oauth` to `null` to ignore a client default `oauth` array and fall back to the constructor configuration.
+Client default request options are honored. If a client has a default `oauth`
+array, a request-level `oauth` array replaces that default array. Set request
+`oauth` to `null` to ignore a client default `oauth` array and fall back to the
+constructor configuration.
 
-Set request `oauth.token` or `oauth.token_secret` to `null` to remove that configured token value for the request. Empty strings are preserved and sent or used as empty credential values.
+Set request `oauth.token` or `oauth.token_secret` to `null` to remove that
+configured token value for the request. Empty strings are preserved and sent or
+used as empty credential values.
 
 ## Request Options
 
-These request options control whether the middleware signs a request and whether token credentials are overridden:
+These request options control whether the middleware signs a request and whether
+token credentials are overridden:
 
 | Option | Description |
 |--------|-------------|
@@ -129,7 +159,9 @@ These request options control whether the middleware signs a request and whether
 
 ## Two-Legged OAuth
 
-For two-legged OAuth, omit `token` and `token_secret`, set them to `null` with the per-request `oauth` option, or set them to empty strings if the service expects an empty `oauth_token` parameter.
+For two-legged OAuth, omit `token` and `token_secret`, set them to `null` with
+the per-request `oauth` option, or set them to empty strings if the service
+expects an empty `oauth_token` parameter.
 
 ```php
 $middleware = new Oauth1([
@@ -166,7 +198,8 @@ Set the `signature_method` constructor option to change how requests are signed.
 
 ### HMAC-SHA1 and HMAC-SHA256
 
-`HMAC-SHA1` is the default signature method. `HMAC-SHA256` is also supported for services that require it.
+`HMAC-SHA1` is the default signature method. `HMAC-SHA256` is also supported for
+services that require it.
 
 ```php
 $middleware = new Oauth1([
@@ -178,11 +211,14 @@ $middleware = new Oauth1([
 ]);
 ```
 
-HMAC signatures use `consumer_secret` and, when set, `token_secret` as the signing key material.
+HMAC signatures use `consumer_secret` and, when set, `token_secret` as the
+signing key material.
 
 ### RSA-SHA1
 
-Use `RSA-SHA1` when the service expects signatures generated with an RSA private key. The PHP OpenSSL extension must be available, and `private_key_file` must point to a readable private key.
+Use `RSA-SHA1` when the service expects signatures generated with an RSA private
+key. The PHP OpenSSL extension must be available, and `private_key_file` must
+point to a readable private key.
 
 ```php
 use GuzzleHttp\Client;
@@ -210,7 +246,8 @@ $response = $client->get('resource', ['auth' => 'oauth']);
 
 ### PLAINTEXT
 
-`PLAINTEXT` uses the prepared OAuth signature base string as the signature input. Use it only when required by the service and only over TLS.
+`PLAINTEXT` uses the prepared OAuth signature base string as the signature
+input. Use it only when required by the service and only over TLS.
 
 ```php
 $middleware = new Oauth1([
@@ -224,11 +261,18 @@ $middleware = new Oauth1([
 
 ## Secret Handling and Retries
 
-OAuth credentials are secrets. Avoid logging request options that contain `oauth`, `consumer_secret`, `token`, or `token_secret` values.
+OAuth credentials are secrets. Avoid logging request options that contain
+`oauth`, `consumer_secret`, `token`, or `token_secret` values.
 
-For signed requests, the middleware removes the per-request `oauth` option before passing the request to the next handler, but custom middleware that runs before `Oauth1` can still inspect it. If a request includes `oauth` options without `'auth' => 'oauth'`, those options are not consumed by this middleware. Place logging middleware so it does not record sensitive request options.
+For signed requests, the middleware removes the per-request `oauth` option
+before passing the request to the next handler, but custom middleware that runs
+before `Oauth1` can still inspect it. If a request includes `oauth` options
+without `'auth' => 'oauth'`, those options are not consumed by this middleware.
+Place logging middleware so it does not record sensitive request options.
 
-If custom retry middleware refreshes credentials, make sure each retry re-enters this middleware. Otherwise the retried request might reuse an old signature, nonce, timestamp, or token value.
+If custom retry middleware refreshes credentials, make sure each retry re-enters
+this middleware. Otherwise the retried request might reuse an old signature,
+nonce, timestamp, or token value.
 
 ## Related
 


### PR DESCRIPTION
Reflows the documentation prose in the docs pages to a greedy 80-column width so the Markdown reads consistently and diffs stay small. This only moves line breaks; no wording changes, and fenced code blocks, tables, and headings are left untouched. There are no code changes.