### PR TITLE
Wrap README prose to 80 columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # Guzzle OAuth Subscriber
 
-`guzzlehttp/oauth-subscriber` is OAuth 1.0 middleware for Guzzle. It signs outgoing Guzzle requests with OAuth credentials when the request uses the `auth` option value `oauth`.
+`guzzlehttp/oauth-subscriber` is OAuth 1.0 middleware for Guzzle. It signs
+outgoing Guzzle requests with OAuth credentials when the request uses the `auth`
+option value `oauth`.
 
-Use this package when an API requires OAuth 1.0 request signing. If an API uses OAuth 2.0 bearer tokens, you usually do not need this package; send an `Authorization: Bearer ...` header with Guzzle instead.
+Use this package when an API requires OAuth 1.0 request signing. If an API uses
+OAuth 2.0 bearer tokens, you usually do not need this package; send an
+`Authorization: Bearer ...` header with Guzzle instead.
 
 ## Installation
 
@@ -40,7 +44,8 @@ $client = new Client([
 $response = $client->get('resource', ['auth' => 'oauth']);
 ```
 
-You can also set `'auth' => 'oauth'` as a client default when every request sent by that client should be signed.
+You can also set `'auth' => 'oauth'` as a client default when every request sent
+by that client should be signed.
 
 ## Documentation
 
@@ -51,10 +56,18 @@ You can also set `'auth' => 'oauth'` as a client default when every request sent
 
 ## Security
 
-OAuth credentials are secrets. Avoid logging request options that contain `oauth` values, and make sure retry middleware re-enters this middleware when refreshed credentials must be used.
+OAuth credentials are secrets. Avoid logging request options that contain
+`oauth` values, and make sure retry middleware re-enters this middleware when
+refreshed credentials must be used.
 
-If you discover a security vulnerability within this package, please send an email to security@tidelift.com. All security vulnerabilities will be promptly addressed. Please do not disclose security-related issues publicly until a fix has been announced. Please see [Security Policy](https://github.com/guzzle/oauth-subscriber/security/policy) for more information.
+If you discover a security vulnerability within this package, please send an
+email to security@tidelift.com. All security vulnerabilities will be promptly
+addressed. Please do not disclose security-related issues publicly until a fix
+has been announced. Please see
+[Security Policy](https://github.com/guzzle/oauth-subscriber/security/policy)
+for more information.
 
 ## License
 
-Guzzle OAuth Subscriber is made available under the MIT License (MIT). Please see [License File](LICENSE) for more information.
+Guzzle OAuth Subscriber is made available under the MIT License (MIT). Please
+see [License File](LICENSE) for more information.


### PR DESCRIPTION
Reflows the README prose to a greedy 80-column width so the Markdown reads consistently and diffs stay small. Only line breaks change; no wording changes, and badges, code blocks, tables, and links are left untouched. There are no code changes.