### PR TITLE
Adopt the psr7 ASCII case folding helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 0.9.5 - Upcoming
+
+* Require `guzzlehttp/psr7` ^2.13
+* Use locale-independent ASCII case folding for signature base string inputs
+
 ## 0.9.4 - 2026-07-08
 
 * Require `guzzlehttp/guzzle` ^7.13.3 and `guzzlehttp/psr7` ^2.12.4

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "require": {
         "php": "^7.2.5 || ^8.0",
         "guzzlehttp/guzzle": "^7.13.3",
-        "guzzlehttp/psr7": "^2.12.4"
+        "guzzlehttp/psr7": "^2.13@dev"
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.8.2",

--- a/src/Oauth1.php
+++ b/src/Oauth1.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GuzzleHttp\Subscriber\Oauth;
 
 use GuzzleHttp\Psr7\Query;
+use GuzzleHttp\Psr7\Utils;
 use Psr\Http\Message\RequestInterface;
 
 /**
@@ -192,7 +193,7 @@ class Oauth1
     {
         // Add POST fields if the request uses POST fields and no files
         $contentType = $request->getHeaderLine('Content-Type');
-        $mediaType = strtolower(trim(explode(';', $contentType, 2)[0], " \n\r\t\0\x0B"));
+        $mediaType = Utils::asciiToLower(trim(explode(';', $contentType, 2)[0], " \n\r\t\0\x0B"));
 
         if ($mediaType === 'application/x-www-form-urlencoded') {
             $body = Query::parse($request->getBody()->getContents());
@@ -248,7 +249,7 @@ class Oauth1
     private static function createBaseString(RequestInterface $request, array $params): string
     {
         // Remove query params from URL. Ref: Spec: 9.1.2.
-        return strtoupper($request->getMethod())
+        return Utils::asciiToUpper($request->getMethod())
             .'&'.rawurlencode((string) $request->getUri()->withQuery(''))
             .'&'.rawurlencode(Query::build($params));
     }


### PR DESCRIPTION
This converts both signature base string inputs to the `Psr7\Utils::asciiToLower()` and `asciiToUpper()` helpers introduced by guzzle/psr7#850, because `strtolower()` and `strtoupper()` honor `LC_CTYPE` before PHP 8.2 and can misfold the form-encoded media type check or the request method under single-byte locales such as Turkish, producing wrong OAuth signatures. The psr7 floor moves to `^2.13@dev` for now so CI resolves the 2.13 branch until 2.13.0 is tagged. Per the 0.x release policy this lands directly on 0.9.x with no separate patch round. This PR needs guzzle/psr7#850 merged before its CI can pass.