### PR TITLE
Adopt the psr7 ASCII case folding helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,10 @@
   where they are accepted and we need to cast to a string, we should branch on
   `\is_finite($value)`, using `(string) $value` for the finite case and
   `\is_nan($value) ? 'NAN' : ($value > 0 ? 'INF' : '-INF')` otherwise.
+- Never call `strtolower()`, `strtoupper()`, `strcasecmp()`, `stripos()`, or
+  other locale-sensitive case functions; use the locale-independent
+  `GuzzleHttp\Psr7\Utils::asciiToLower()`, `asciiToUpper()`,
+  `caselessEquals()`, and `caselessContains()` helpers instead.
 - Changes in behavior need a `CHANGELOG.md` entry in the unreleased section of
   the target branch and an `UPGRADING.md` note when the behavior differs between
   major versions.

--- a/src/Oauth1.php
+++ b/src/Oauth1.php
@@ -6,6 +6,7 @@ namespace GuzzleHttp\Subscriber\Oauth;
 
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\Query;
+use GuzzleHttp\Psr7\Utils;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -224,7 +225,7 @@ class Oauth1
     {
         // Add POST fields if the request uses POST fields and no files
         $contentType = $request->getHeaderLine('Content-Type');
-        $mediaType = strtolower(trim(explode(';', $contentType, 2)[0], " \t"));
+        $mediaType = Utils::asciiToLower(trim(explode(';', $contentType, 2)[0], " \t"));
 
         if ($mediaType === 'application/x-www-form-urlencoded') {
             $body = Query::parse($request->getBody()->getContents());
@@ -280,7 +281,7 @@ class Oauth1
     private static function createBaseString(RequestInterface $request, array $params): string
     {
         // Remove query params from URL. Ref: Spec: 9.1.2.
-        return strtoupper($request->getMethod())
+        return Utils::asciiToUpper($request->getMethod())
             .'&'.rawurlencode((string) $request->getUri()->withQuery(''))
             .'&'.rawurlencode(Query::build($params));
     }


### PR DESCRIPTION
This mirrors #146 for 1.0, carrying the code changes since only the changelog is merged up: both signature base string inputs — the form-encoded media type check and the request method — now use `Psr7\Utils::asciiToLower()` and `asciiToUpper()`, preserving this branch's own trim characters, and `AGENTS.md` gains the bullet mandating the locale-independent helpers. Needs guzzle/psr7#851 merged before CI can pass.