### PR TITLE
Escape unsafe OAuth configuration diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,9 @@
 - Handle `preg_*` engine failures: when the result is used as data, test for
   `false` or `null` and throw a `\RuntimeException` including
   `preg_last_error_msg()`; boolean validation guards must compare strictly, such
-  as `=== 1`, so an engine failure can only ever fail closed.
+  as `=== 1`, so an engine failure can only ever fail closed. Diagnostic
+  escaping is the narrow exception: use a deterministic bytewise fallback rather
+  than throwing, so it cannot obscure the original exception.
 - Anchor validation patterns to the true end of input with the `D` modifier or
   `\z`; a bare `$` accepts a trailing newline.
 - Never embed raw control bytes in exception messages and other diagnostics;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Dropped support for PHP 7.2 and 7.3
 * Switched from Guzzle 7.x to 8.x and from Guzzle PSR-7 2.x to 3.x
+* Escape unsafe configuration values in generated OAuth exceptions
 * Reject native PHP serialization of `Oauth1`
 * Reject non-finite float values in OAuth parameters
 * Added native return types to the OAuth middleware entry point

--- a/src/Oauth1.php
+++ b/src/Oauth1.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GuzzleHttp\Subscriber\Oauth;
 
 use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Psr7\DiagnosticValue;
 use GuzzleHttp\Psr7\Query;
 use GuzzleHttp\Psr7\Utils;
 use Psr\Http\Message\RequestInterface;
@@ -188,10 +189,7 @@ class Oauth1
                 $request = $request->withUri($request->getUri()->withQuery($preparedParams));
                 break;
             default:
-                throw new \InvalidArgumentException(sprintf(
-                    'Invalid consumer method "%s"',
-                    $config['request_method']
-                ));
+                throw new \InvalidArgumentException(\sprintf('Invalid consumer method: %s', DiagnosticValue::escape((string) $config['request_method'])));
         }
 
         return $request;
@@ -260,7 +258,7 @@ class Oauth1
                 $signature = self::signUsingPlaintext($baseString);
                 break;
             default:
-                throw new \RuntimeException('Unknown signature method: '.$config['signature_method']);
+                throw new \RuntimeException(\sprintf('Unknown signature method: %s', DiagnosticValue::escape((string) $config['signature_method'])));
         }
 
         return base64_encode($signature);
@@ -387,10 +385,7 @@ class Oauth1
 
         $keyContents = @file_get_contents($config['private_key_file']);
         if ($keyContents === false) {
-            throw new \RuntimeException(sprintf(
-                'Unable to read RSA private key file: %s',
-                $config['private_key_file']
-            ));
+            throw new \RuntimeException(\sprintf('Unable to read RSA private key file: %s', DiagnosticValue::escape($config['private_key_file'])));
         }
 
         if (isset($config['private_key_passphrase'])) {

--- a/tests/Oauth1Test.php
+++ b/tests/Oauth1Test.php
@@ -786,6 +786,55 @@ class Oauth1Test extends TestCase
         $client->get('https://example.com', ['auth' => 'oauth']);
     }
 
+    /**
+     * @param class-string<\Throwable> $expectedException
+     *
+     * @dataProvider unsafeConfigurationValueProvider
+     */
+    public function testEscapesUnsafeConfigurationValues(string $option, string $value, string $expectedException, string $expectedMessage): void
+    {
+        if ($option === 'private_key_file' && !function_exists('openssl_pkey_get_private')) {
+            $this->markTestSkipped('OpenSSL extension is not available.');
+        }
+
+        $config = $this->config;
+        $config[$option] = $value;
+        if ($option === 'private_key_file') {
+            $config['signature_method'] = Oauth1::SIGNATURE_METHOD_RSA;
+        }
+
+        $oauth = new Oauth1($config);
+        $this->expectException($expectedException);
+        $this->expectExceptionMessage($expectedMessage);
+
+        if ($option === 'request_method') {
+            $container = [];
+            $client = $this->createClientWithHistory($oauth, $container);
+            $client->get('https://example.com', ['auth' => 'oauth']);
+
+            return;
+        }
+
+        $oauth->getSignature(new Request('GET', 'https://example.com'), []);
+    }
+
+    public static function unsafeConfigurationValueProvider(): array
+    {
+        $c1 = "value\xC2\x9B";
+        $malformed = "value\xFF";
+        $c1Path = __DIR__."/missing-\xC2\x9B.pem";
+        $malformedPath = __DIR__."/missing-\xFF.pem";
+
+        return [
+            'request method with C1 control' => ['request_method', $c1, \InvalidArgumentException::class, 'Invalid consumer method: value\\x9B'],
+            'request method with malformed UTF-8' => ['request_method', $malformed, \InvalidArgumentException::class, 'Invalid consumer method: value\\xFF'],
+            'signature method with C1 control' => ['signature_method', $c1, \RuntimeException::class, 'Unknown signature method: value\\x9B'],
+            'signature method with malformed UTF-8' => ['signature_method', $malformed, \RuntimeException::class, 'Unknown signature method: value\\xFF'],
+            'private key path with C1 control' => ['private_key_file', $c1Path, \RuntimeException::class, 'Unable to read RSA private key file: '.__DIR__.'/missing-\\x9B.pem'],
+            'private key path with malformed UTF-8' => ['private_key_file', $malformedPath, \RuntimeException::class, 'Unable to read RSA private key file: '.__DIR__.'/missing-\\xFF.pem'],
+        ];
+    }
+
     public function testExceptionOnMissingRsaPrivateKeyFileOption(): void
     {
         if (!function_exists('openssl_pkey_get_private')) {


### PR DESCRIPTION
OAuth Subscriber 1 includes rejected method names and private-key paths in generated configuration exceptions. This uses the PSR-7 diagnostic helper to render controls and malformed UTF-8 visibly without exposing additional credential material or changing the original configuration values.